### PR TITLE
fix: correct directory path for PDF and RST files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .vscode/
 kfs.bin
 kfs.iso
-Documents/*.pdf
-Documents/*.rst
+Documentation/*.pdf
+Documentation/*.rst


### PR DESCRIPTION
#10

## Summary
fix: correct directory path for PDF and RST files in .gitignore