### PR TITLE
Update Docker image version to 1.0.2 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include .env
 export
 
 # ===== Docker image settings =====
-IMAGE ?= smizuoch/kfs:1.0.1
+IMAGE ?= smizuoch/kfs:1.0.2
 DOCKER ?= docker
 ISA	?= i386
 PWD := $(shell pwd)


### PR DESCRIPTION
#37


## Summary
This pull request updates the Docker image version used in the `Makefile` from `1.0.1` to `1.0.2`. This is a minor change to ensure the build uses the latest image.
