### PR TITLE
feat: don't delete header files with make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ TEST_SRCS_C   := $(shell find ./test -name '*.c' -print)
 TEST_SRCS_H   := $(shell find ./test -name '*.h' -print)
 TEST_SRCS_SH  := $(shell find ./test -name '*.sh' -print)
 
-KERNEL_SRCS := $(KERNEL_SRCS_C) $(KERNEL_SRCS_H) $(KERNEL_SRCS_S)
-TEST_SRCS := $(TEST_SRCS_C) $(TEST_SRCS_H) $(TEST_SRCS_SH)
+KERNEL_SRCS := $(KERNEL_SRCS_C) $(KERNEL_SRCS_S)
+TEST_SRCS := $(TEST_SRCS_C) $(TEST_SRCS_SH)
 KERNEL_OBJS := $(patsubst %.S,%.o,$(patsubst %.c,%.o,$(KERNEL_SRCS)))
 
 KERNEL := kfs.bin


### PR DESCRIPTION
#41 

Why make clean deleted the header file:
- make clean deletes $(KERNEL_OBJS) and isodir/.
- $(KERNEL_OBJS) contained the header file. << **wow!**