### PR TITLE
Update ISO generation command to include specific GRUB modules and enable compression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ iso: kernel grub.cfg
 	mkdir -p isodir/boot/grub
 	cp $(KERNEL) isodir/boot/kfs.bin
 	cp grub.cfg isodir/boot/grub/grub.cfg
-	grub-mkrescue -o $(ISO) isodir
+	grub-mkrescue -o $(ISO) isodir --modules="multiboot normal configfile" --compress=xz
 
 clean:
 	rm -rf isodir $(ISO)


### PR DESCRIPTION
#46 


## Summary
This pull request updates the ISO generation process in the `Makefile` to improve bootloader support and reduce ISO size. The main change is the addition of specific GRUB modules and compression options when creating the ISO.

Enhancements to ISO creation:

* Updated the `grub-mkrescue` command to explicitly include the `multiboot`, `normal`, and `configfile` GRUB modules, and enabled XZ compression for the ISO, which should improve compatibility and reduce the ISO file size.
