### PR TITLE
Bug/#51/the vga output and terminal output do not match

### DIFF
--- a/drivers/video/terminal.c
+++ b/drivers/video/terminal.c
@@ -96,6 +96,7 @@ void terminal_write(const char *data, size_t size)
 }
 void terminal_writestring(const char *s)
 {
+	serial_write(s, strlen(s)); //Required to capture VGA output during integration testing. Remove once the mechanism is in place.
 	terminal_write(s, strlen(s));
 }
 

--- a/drivers/video/terminal.c
+++ b/drivers/video/terminal.c
@@ -96,7 +96,8 @@ void terminal_write(const char *data, size_t size)
 }
 void terminal_writestring(const char *s)
 {
-	serial_write(s, strlen(s)); //Required to capture VGA output during integration testing. Remove once the mechanism is in place.
+	// Required to capture VGA output during integration testing. Remove once the mechanism is in place.
+	serial_write(s, strlen(s));
 	terminal_write(s, strlen(s));
 }
 

--- a/init/main.c
+++ b/init/main.c
@@ -6,11 +6,7 @@ void kernel_main(void)
 	serial_init();
 	terminal_initialize();
 	/* Integration test expects '42' on the serial (COM1) output. */
-	serial_write("42\n", 3);
 	terminal_writestring("42\n");
-	terminal_writestring("Hello, kernel World!\n");
-	terminal_writestring("This is a minimal i386 kernel.\n");
-	terminal_writestring("Newline and scrolling are supported.\n");
 }
 
 /* テスト用ラッパは drivers 実装側に残存 */


### PR DESCRIPTION
#51


## Summary
This pull request updates how output is sent to the serial port during kernel initialization and modifies the terminal output functions to support integration testing. The main changes focus on ensuring that serial output matches VGA output for test purposes.

Integration testing support:

* Updated `terminal_writestring` in `drivers/video/terminal.c` to call `serial_write` so that all terminal output is also sent to the serial port, which is necessary for capturing VGA output during integration tests.

Kernel initialization changes:

* Removed the direct call to `serial_write("42\n", 3)` in `init/main.c` and now send `"42\n"` via `terminal_writestring`, ensuring both serial and VGA outputs are synchronized for integration testing.
* Removed additional informational messages from `kernel_main` to streamline output during testing.
