### PR TITLE
Fr/#55/a world where pressing keys yields no text is a bleak one so lets define it such that text does appear

### DIFF
--- a/drivers/char/serial.c
+++ b/drivers/char/serial.c
@@ -9,6 +9,10 @@ __attribute__((weak)) void kfs_io_outb(uint16_t port, uint8_t val)
 {
 	__asm__ volatile("outb %0, %1" : : "a"(val), "Nd"(port));
 }
+/*
+kfs_io_inb(PS2_DATA_PORT); は「I/O ポート 0x60 (PS/2 コントローラのデータポート) から 1
+バイト読み取る」ための低レベル入力命令ラッパ呼び出しです。
+*/
 __attribute__((weak)) uint8_t kfs_io_inb(uint16_t port)
 {
 	uint8_t r;

--- a/drivers/tty/keyboard.c
+++ b/drivers/tty/keyboard.c
@@ -1,0 +1,184 @@
+#include <kfs/kfs1_bonus.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define PS2_STATUS_PORT 0x64
+#define PS2_DATA_PORT 0x60
+
+static int left_shift;
+static int right_shift;
+static int alt_pressed;
+static int caps_lock;
+static int extended_prefix;
+static int keyboard_initialized;
+
+extern uint8_t kfs_io_inb(uint16_t port);
+
+static const char scancode_map_normal[128] = {
+	[0x02] = '1',  [0x03] = '2', [0x04] = '3',	[0x05] = '4', [0x06] = '5', [0x07] = '6',  [0x08] = '7',
+	[0x09] = '8',  [0x0A] = '9', [0x0B] = '0',	[0x0C] = '-', [0x0D] = '=', [0x0F] = '\t', [0x10] = 'q',
+	[0x11] = 'w',  [0x12] = 'e', [0x13] = 'r',	[0x14] = 't', [0x15] = 'y', [0x16] = 'u',  [0x17] = 'i',
+	[0x18] = 'o',  [0x19] = 'p', [0x1A] = '[',	[0x1B] = ']', [0x1E] = 'a', [0x1F] = 's',  [0x20] = 'd',
+	[0x21] = 'f',  [0x22] = 'g', [0x23] = 'h',	[0x24] = 'j', [0x25] = 'k', [0x26] = 'l',  [0x27] = ';',
+	[0x28] = '\'', [0x29] = '`', [0x2B] = '\\', [0x2C] = 'z', [0x2D] = 'x', [0x2E] = 'c',  [0x2F] = 'v',
+	[0x30] = 'b',  [0x31] = 'n', [0x32] = 'm',	[0x33] = ',', [0x34] = '.', [0x35] = '/',  [0x39] = ' ',
+};
+
+static const char scancode_map_shift[128] = {
+	[0x02] = '!', [0x03] = '@', [0x04] = '#', [0x05] = '$', [0x06] = '%', [0x07] = '^', [0x08] = '&', [0x09] = '*',
+	[0x0A] = '(', [0x0B] = ')', [0x0C] = '_', [0x0D] = '+', [0x10] = 'Q', [0x11] = 'W', [0x12] = 'E', [0x13] = 'R',
+	[0x14] = 'T', [0x15] = 'Y', [0x16] = 'U', [0x17] = 'I', [0x18] = 'O', [0x19] = 'P', [0x1A] = '{', [0x1B] = '}',
+	[0x1E] = 'A', [0x1F] = 'S', [0x20] = 'D', [0x21] = 'F', [0x22] = 'G', [0x23] = 'H', [0x24] = 'J', [0x25] = 'K',
+	[0x26] = 'L', [0x27] = ':', [0x28] = '"', [0x29] = '~', [0x2B] = '|', [0x2C] = 'Z', [0x2D] = 'X', [0x2E] = 'C',
+	[0x2F] = 'V', [0x30] = 'B', [0x31] = 'N', [0x32] = 'M', [0x33] = '<', [0x34] = '>', [0x35] = '?',
+};
+
+static int shift_active(void)
+{
+	return left_shift || right_shift;
+}
+
+static char translate_scancode(uint8_t code)
+{
+	char base = scancode_map_normal[code];
+	if (!base)
+		return 0;
+	if (base >= 'a' && base <= 'z')
+	{
+		int upper = caps_lock ^ shift_active();
+		return (char)(upper ? (base - ('a' - 'A')) : base);
+	}
+	if (shift_active())
+	{
+		char shifted = scancode_map_shift[code];
+		if (shifted)
+			return shifted;
+	}
+	return base;
+}
+
+static void handle_backspace(void)
+{
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	if (col > 0)
+	{
+		kfs_terminal_move_cursor(row, col - 1);
+		terminal_putchar(' ');
+		kfs_terminal_move_cursor(row, col - 1);
+	}
+	else if (row > 0)
+	{
+		size_t new_col = KFS_VGA_WIDTH - 1;
+		kfs_terminal_move_cursor(row - 1, new_col);
+		terminal_putchar(' ');
+		kfs_terminal_move_cursor(row - 1, new_col);
+	}
+}
+
+void kfs_keyboard_reset(void)
+{
+	left_shift = 0;
+	right_shift = 0;
+	alt_pressed = 0;
+	caps_lock = 0;
+	extended_prefix = 0;
+	keyboard_initialized = 0;
+}
+
+void kfs_keyboard_init(void)
+{
+	kfs_keyboard_reset();
+	keyboard_initialized = 1;
+	/* Drain any pending bytes so we start from a clean state. */
+	while (kfs_io_inb(PS2_STATUS_PORT) & 0x01)
+	{
+		(void)kfs_io_inb(PS2_DATA_PORT);
+	}
+}
+
+void kfs_keyboard_feed_scancode(uint8_t scancode)
+{
+	if (scancode == 0xE0 || scancode == 0xE1)
+	{
+		extended_prefix = scancode;
+		return;
+	}
+	int release = (scancode & 0x80) != 0;
+	uint8_t code = scancode & 0x7F;
+	switch (code)
+	{
+	case 0x2A:
+		left_shift = release ? 0 : 1;
+		extended_prefix = 0;
+		return;
+	case 0x36:
+		right_shift = release ? 0 : 1;
+		extended_prefix = 0;
+		return;
+	case 0x38:
+		alt_pressed = release ? 0 : 1;
+		extended_prefix = 0;
+		return;
+	case 0x3A:
+		if (!release)
+			caps_lock = !caps_lock;
+		extended_prefix = 0;
+		return;
+	case 0x0E:
+		if (!release)
+			handle_backspace();
+		extended_prefix = 0;
+		return;
+	/* Enter */
+	case 0x1C:
+		if (!release)
+			terminal_putchar('\n');
+		extended_prefix = 0;
+		return;
+	/* F1 - F4 */
+	case 0x3B:
+	case 0x3C:
+	case 0x3D:
+	case 0x3E:
+		if (!release && alt_pressed)
+		{
+			size_t target = (size_t)(code - 0x3B);
+			if (target < kfs_terminal_console_count())
+				kfs_terminal_switch_console(target);
+		}
+		extended_prefix = 0;
+		return;
+	default:
+		break;
+	}
+	if (release)
+	{
+		extended_prefix = 0;
+		return;
+	}
+	if (extended_prefix)
+	{
+		extended_prefix = 0;
+		return;
+	}
+	extended_prefix = 0;
+	char ch = translate_scancode(code);
+	if (ch)
+		terminal_putchar(ch);
+}
+
+void kfs_keyboard_poll(void)
+{
+	if (!keyboard_initialized)
+		return;
+	for (;;)
+	{
+		uint8_t status = kfs_io_inb(PS2_STATUS_PORT);
+		if (!(status & 0x01))
+			break;
+		uint8_t scancode = kfs_io_inb(PS2_DATA_PORT);
+		kfs_keyboard_feed_scancode(scancode);
+	}
+}

--- a/drivers/video/terminal.c
+++ b/drivers/video/terminal.c
@@ -1,91 +1,204 @@
-#include <linux/string.h> /* strlen */
-#include <linux/terminal.h>
+#include <kfs/kfs1_bonus.h>
+#include <linux/string.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#define VGA_WIDTH 80
-#define VGA_HEIGHT 25
+#define VGA_WIDTH KFS_VGA_WIDTH
+#define VGA_HEIGHT KFS_VGA_HEIGHT
 #define VGA_MEMORY 0xB8000
+#define VGA_CRTC_COMMAND_PORT 0x3D4
+#define VGA_CRTC_DATA_PORT 0x3D5
 
-/* Internal terminal state (kept global; not part of public header). */
+extern void kfs_io_outb(uint16_t port, uint8_t val);
+
 size_t kfs_terminal_row;
 size_t kfs_terminal_column;
 uint8_t kfs_terminal_color;
-uint16_t *kfs_terminal_buffer = (uint16_t *)VGA_MEMORY; /* Default VGA memory */
+uint16_t *kfs_terminal_buffer = (uint16_t *)VGA_MEMORY;
 
-static inline uint8_t vga_entry_color(uint8_t fg, uint8_t bg)
+struct kfs_console_state
 {
-	return fg | bg << 4;
-}
-static inline uint16_t vga_entry(unsigned char uc, uint8_t color)
+	size_t row;
+	size_t column;
+	uint8_t color;
+	uint16_t shadow[VGA_WIDTH * VGA_HEIGHT];
+	int initialized;
+};
+
+static struct kfs_console_state kfs_console_states[KFS_VIRTUAL_CONSOLE_COUNT];
+static size_t kfs_console_active;
+static int kfs_console_bootstrap_completed;
+
+static struct kfs_console_state *active_console(void)
 {
-	return (uint16_t)uc | (uint16_t)color << 8;
+	return &kfs_console_states[kfs_console_active];
 }
 
-static void terminal_clear(void)
+static int console_is_active(const struct kfs_console_state *con)
 {
-	for (size_t y = 0; y < VGA_HEIGHT; y++)
+	return con == &kfs_console_states[kfs_console_active];
+}
+
+uint8_t kfs_vga_make_color(enum vga_color fg, enum vga_color bg)
+{
+	return (uint8_t)(fg | (bg << 4));
+}
+
+uint16_t kfs_vga_make_entry(char c, uint8_t color)
+{
+	return (uint16_t)c | ((uint16_t)color << 8);
+}
+
+static void console_fill_blank(struct kfs_console_state *con)
+{
+	uint16_t blank = kfs_vga_make_entry(' ', con->color);
+	for (size_t i = 0; i < VGA_WIDTH * VGA_HEIGHT; ++i)
+		con->shadow[i] = blank;
+}
+
+static void console_flush_to_hw(const struct kfs_console_state *con)
+{
+	if (!kfs_terminal_buffer)
+		return;
+	for (size_t i = 0; i < VGA_WIDTH * VGA_HEIGHT; ++i)
+		kfs_terminal_buffer[i] = con->shadow[i];
+}
+
+static void console_capture_from_hw(struct kfs_console_state *con)
+{
+	if (!kfs_terminal_buffer)
+		return;
+	for (size_t i = 0; i < VGA_WIDTH * VGA_HEIGHT; ++i)
+		con->shadow[i] = kfs_terminal_buffer[i];
+}
+
+static void ensure_console_bootstrap(void)
+{
+	if (kfs_console_bootstrap_completed)
+		return;
+	uint8_t default_color = kfs_vga_make_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
+	for (size_t i = 0; i < KFS_VIRTUAL_CONSOLE_COUNT; ++i)
 	{
-		for (size_t x = 0; x < VGA_WIDTH; x++)
-		{
-			kfs_terminal_buffer[y * VGA_WIDTH + x] = vga_entry(' ', kfs_terminal_color);
-		}
+		struct kfs_console_state *con = &kfs_console_states[i];
+		con->row = 0;
+		con->column = 0;
+		con->color = default_color;
+		con->initialized = 0;
+		console_fill_blank(con);
+	}
+	kfs_console_active = 0;
+	kfs_console_bootstrap_completed = 1;
+}
+
+static void terminal_update_hw_cursor(size_t row, size_t column)
+{
+	uint16_t pos = (uint16_t)(row * VGA_WIDTH + column);
+	kfs_io_outb(VGA_CRTC_COMMAND_PORT, 0x0F);
+	kfs_io_outb(VGA_CRTC_DATA_PORT, (uint8_t)(pos & 0xFF));
+	kfs_io_outb(VGA_CRTC_COMMAND_PORT, 0x0E);
+	kfs_io_outb(VGA_CRTC_DATA_PORT, (uint8_t)((pos >> 8) & 0xFF));
+}
+
+static void sync_globals_from_console(const struct kfs_console_state *con)
+{
+	kfs_terminal_row = con->row;
+	kfs_terminal_column = con->column;
+	kfs_terminal_color = con->color;
+	terminal_update_hw_cursor(kfs_terminal_row, kfs_terminal_column);
+}
+
+static void console_activate_if_needed(struct kfs_console_state *con)
+{
+	if (!con->initialized)
+	{
+		con->row = 0;
+		con->column = 0;
+		con->color = kfs_vga_make_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
+		con->initialized = 1;
+		console_fill_blank(con);
+		if (console_is_active(con))
+			console_flush_to_hw(con);
 	}
 }
 
 void terminal_initialize(void)
 {
-	kfs_terminal_row = 0;
-	kfs_terminal_column = 0;
-	kfs_terminal_color = vga_entry_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
-	terminal_clear();
+	ensure_console_bootstrap();
+	struct kfs_console_state *con = active_console();
+	con->color = kfs_vga_make_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
+	con->row = 0;
+	con->column = 0;
+	con->initialized = 1;
+	console_fill_blank(con);
+	console_flush_to_hw(con);
+	sync_globals_from_console(con);
 }
 
 void terminal_setcolor(uint8_t color)
 {
-	kfs_terminal_color = color;
+	kfs_terminal_set_color(color);
 }
 
-static void terminal_scroll_if_needed(void)
+static void terminal_putentryat(struct kfs_console_state *con, char c, size_t x, size_t y)
 {
-	if (kfs_terminal_row < VGA_HEIGHT)
+	uint16_t entry = kfs_vga_make_entry(c, con->color);
+	con->shadow[y * VGA_WIDTH + x] = entry;
+	if (console_is_active(con) && kfs_terminal_buffer)
+		kfs_terminal_buffer[y * VGA_WIDTH + x] = entry;
+}
+
+static void terminal_scroll_if_needed(struct kfs_console_state *con)
+{
+	if (con->row < VGA_HEIGHT)
 		return;
+	int flush_hw = console_is_active(con) && kfs_terminal_buffer;
 	for (size_t y = 1; y < VGA_HEIGHT; y++)
 	{
 		for (size_t x = 0; x < VGA_WIDTH; x++)
-			kfs_terminal_buffer[(y - 1) * VGA_WIDTH + x] = kfs_terminal_buffer[y * VGA_WIDTH + x];
+		{
+			uint16_t value = con->shadow[y * VGA_WIDTH + x];
+			con->shadow[(y - 1) * VGA_WIDTH + x] = value;
+			if (flush_hw)
+				kfs_terminal_buffer[(y - 1) * VGA_WIDTH + x] = value;
+		}
 	}
+	uint16_t blank = kfs_vga_make_entry(' ', con->color);
 	for (size_t x = 0; x < VGA_WIDTH; x++)
-		kfs_terminal_buffer[(VGA_HEIGHT - 1) * VGA_WIDTH + x] = vga_entry(' ', kfs_terminal_color);
-	kfs_terminal_row = VGA_HEIGHT - 1;
-}
-
-static void terminal_putentryat(char c, uint8_t color, size_t x, size_t y)
-{
-	kfs_terminal_buffer[y * VGA_WIDTH + x] = vga_entry(c, color);
+	{
+		con->shadow[(VGA_HEIGHT - 1) * VGA_WIDTH + x] = blank;
+		if (flush_hw)
+			kfs_terminal_buffer[(VGA_HEIGHT - 1) * VGA_WIDTH + x] = blank;
+	}
+	con->row = VGA_HEIGHT - 1;
 }
 
 void terminal_putchar(char c)
 {
+	ensure_console_bootstrap();
+	struct kfs_console_state *con = active_console();
+	console_activate_if_needed(con);
 	if (c == '\n')
 	{
-		kfs_terminal_column = 0;
-		kfs_terminal_row++;
-		terminal_scroll_if_needed();
+		con->column = 0;
+		con->row++;
+		terminal_scroll_if_needed(con);
+		sync_globals_from_console(con);
 		return;
 	}
 	if (c == '\r')
 	{
-		kfs_terminal_column = 0;
+		con->column = 0;
+		sync_globals_from_console(con);
 		return;
 	}
-	terminal_putentryat(c, kfs_terminal_color, kfs_terminal_column, kfs_terminal_row);
-	if (++kfs_terminal_column == VGA_WIDTH)
+	terminal_putentryat(con, c, con->column, con->row);
+	if (++con->column == VGA_WIDTH)
 	{
-		kfs_terminal_column = 0;
-		kfs_terminal_row++;
-		terminal_scroll_if_needed();
+		con->column = 0;
+		con->row++;
 	}
+	terminal_scroll_if_needed(con);
+	sync_globals_from_console(con);
 }
 
 void terminal_write(const char *data, size_t size)
@@ -93,9 +206,72 @@ void terminal_write(const char *data, size_t size)
 	for (size_t i = 0; i < size; i++)
 		terminal_putchar(data[i]);
 }
+
 void terminal_writestring(const char *s)
 {
-	// Required to capture VGA output during integration testing. Remove once the mechanism is in place.
 	serial_write(s, strlen(s));
 	terminal_write(s, strlen(s));
+}
+
+void kfs_terminal_move_cursor(size_t row, size_t column)
+{
+	ensure_console_bootstrap();
+	struct kfs_console_state *con = active_console();
+	if (row >= VGA_HEIGHT)
+		row = VGA_HEIGHT - 1;
+	if (column >= VGA_WIDTH)
+		column = VGA_WIDTH - 1;
+	con->row = row;
+	con->column = column;
+	sync_globals_from_console(con);
+}
+
+void kfs_terminal_get_cursor(size_t *row, size_t *column)
+{
+	ensure_console_bootstrap();
+	struct kfs_console_state *con = active_console();
+	if (row)
+		*row = con->row;
+	if (column)
+		*column = con->column;
+}
+
+void kfs_terminal_set_color(uint8_t color)
+{
+	ensure_console_bootstrap();
+	struct kfs_console_state *con = active_console();
+	con->color = color;
+	kfs_terminal_color = color;
+}
+
+uint8_t kfs_terminal_get_color(void)
+{
+	ensure_console_bootstrap();
+	return active_console()->color;
+}
+
+size_t kfs_terminal_active_console(void)
+{
+	ensure_console_bootstrap();
+	return kfs_console_active;
+}
+
+size_t kfs_terminal_console_count(void)
+{
+	return KFS_VIRTUAL_CONSOLE_COUNT;
+}
+
+void kfs_terminal_switch_console(size_t index)
+{
+	ensure_console_bootstrap();
+	if (index >= KFS_VIRTUAL_CONSOLE_COUNT || index == kfs_console_active)
+		return;
+	struct kfs_console_state *current = active_console();
+	if (current->initialized)
+		console_capture_from_hw(current);
+	kfs_console_active = index;
+	struct kfs_console_state *next = active_console();
+	console_activate_if_needed(next);
+	console_flush_to_hw(next);
+	sync_globals_from_console(next);
 }

--- a/include/kfs/kfs1_bonus.h
+++ b/include/kfs/kfs1_bonus.h
@@ -1,0 +1,74 @@
+#ifndef KFS_KFS1_BONUS_H
+#define KFS_KFS1_BONUS_H
+
+#include <linux/terminal.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define KFS_KERN_SOH "\001"
+#define KERN_SOH KFS_KERN_SOH
+#define KERN_EMERG KFS_KERN_SOH "0"
+#define KERN_ALERT KFS_KERN_SOH "1"
+#define KERN_CRIT KFS_KERN_SOH "2"
+#define KERN_ERR KFS_KERN_SOH "3"
+#define KERN_WARNING KFS_KERN_SOH "4"
+#define KERN_NOTICE KFS_KERN_SOH "5"
+#define KERN_INFO KFS_KERN_SOH "6"
+#define KERN_DEBUG KFS_KERN_SOH "7"
+#define KERN_DEFAULT KFS_KERN_SOH "d"
+#define KERN_CONT KFS_KERN_SOH "c"
+
+#define KFS_VGA_WIDTH 80
+#define KFS_VGA_HEIGHT 25
+#define KFS_VIRTUAL_CONSOLE_COUNT 4
+
+	enum kfs_printk_loglevel
+	{
+		KFS_LOGLEVEL_EMERG = 0,
+		KFS_LOGLEVEL_ALERT = 1,
+		KFS_LOGLEVEL_CRIT = 2,
+		KFS_LOGLEVEL_ERR = 3,
+		KFS_LOGLEVEL_WARNING = 4,
+		KFS_LOGLEVEL_NOTICE = 5,
+		KFS_LOGLEVEL_INFO = 6,
+		KFS_LOGLEVEL_DEBUG = 7,
+		KFS_LOGLEVEL_CONT = 8,
+		KFS_LOGLEVEL_DEFAULT = KFS_LOGLEVEL_WARNING,
+	};
+
+	uint8_t kfs_vga_make_color(enum vga_color fg, enum vga_color bg);
+	uint16_t kfs_vga_make_entry(char c, uint8_t color);
+
+	void kfs_terminal_move_cursor(size_t row, size_t column);
+	void kfs_terminal_get_cursor(size_t *row, size_t *column);
+	void kfs_terminal_set_color(uint8_t color);
+	uint8_t kfs_terminal_get_color(void);
+
+	size_t kfs_terminal_active_console(void);
+	size_t kfs_terminal_console_count(void);
+	void kfs_terminal_switch_console(size_t index);
+
+	void kfs_keyboard_init(void);
+	void kfs_keyboard_reset(void);
+	void kfs_keyboard_feed_scancode(uint8_t scancode);
+	void kfs_keyboard_poll(void);
+
+	void kfs_printk_set_console_loglevel(int level);
+	int kfs_printk_get_console_loglevel(void);
+	int kfs_printk_get_default_loglevel(void);
+	int kfs_vsnprintf(char *buf, size_t size, const char *fmt, va_list ap);
+	int kfs_snprintf(char *buf, size_t size, const char *fmt, ...);
+
+	int printk(const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* KFS_KFS1_BONUS_H */

--- a/init/main.c
+++ b/init/main.c
@@ -1,12 +1,23 @@
 /* Minimal kernel entry using new driver layout */
-#include <linux/terminal.h>
+#include <kfs/kfs1_bonus.h>
 
 void kernel_main(void)
 {
 	serial_init();
 	terminal_initialize();
+	kfs_keyboard_init();
+	kfs_terminal_set_color(kfs_vga_make_color(VGA_COLOR_LIGHT_GREEN, VGA_COLOR_BLACK));
 	/* Integration test expects '42' on the serial (COM1) output. */
-	terminal_writestring("42\n");
+	printk("42\n");
+	kfs_terminal_set_color(kfs_vga_make_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK));
+	printk("Alt+F1..F4 switch consoles; keyboard echo ready.\n");
+	kfs_terminal_set_color(kfs_vga_make_color(VGA_COLOR_LIGHT_CYAN, VGA_COLOR_BLACK));
+#ifndef KFS_HOST_TEST
+	for (;;)
+		kfs_keyboard_poll();
+#else
+	kfs_keyboard_poll();
+#endif
 }
 
 /* テスト用ラッパは drivers 実装側に残存 */

--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -1,0 +1,232 @@
+#include <kfs/kfs1_bonus.h>
+#include <linux/string.h>
+#include <stdarg.h>
+
+static int printk_console_loglevel = KFS_LOGLEVEL_DEFAULT;
+static int printk_default_loglevel = KFS_LOGLEVEL_DEFAULT;
+static int printk_last_loglevel = KFS_LOGLEVEL_DEFAULT;
+static int printk_last_emitted = 1;
+
+static void append_char(char **dst, size_t *remaining, size_t *written, char c)
+{
+	if (*remaining > 1)
+	{
+		**dst = c;
+		(*dst)++;
+		(*remaining)--;
+	}
+	(*written)++;
+}
+
+static void append_string(char **dst, size_t *remaining, size_t *written, const char *s)
+{
+	if (!s)
+		s = "(null)";
+	while (*s)
+	{
+		append_char(dst, remaining, written, *s);
+		s++;
+	}
+}
+
+static void append_unsigned(char **dst, size_t *remaining, size_t *written, unsigned int value, unsigned int base,
+							int uppercase)
+{
+	char buf[32];
+	int idx = 0;
+	if (value == 0)
+	{
+		buf[idx++] = '0';
+	}
+	else
+	{
+		while (value > 0 && idx < (int)sizeof(buf))
+		{
+			unsigned int digit = value % base;
+			value /= base;
+			if (digit < 10)
+				buf[idx++] = (char)('0' + digit);
+			else
+				buf[idx++] = (char)((uppercase ? 'A' : 'a') + (digit - 10));
+		}
+	}
+	while (idx > 0)
+		append_char(dst, remaining, written, buf[--idx]);
+}
+
+static void append_signed(char **dst, size_t *remaining, size_t *written, int value)
+{
+	unsigned int magnitude;
+	if (value < 0)
+	{
+		append_char(dst, remaining, written, '-');
+		magnitude = (unsigned int)(-(long long)value);
+	}
+	else
+	{
+		magnitude = (unsigned int)value;
+	}
+	append_unsigned(dst, remaining, written, magnitude, 10, 0);
+}
+
+int kfs_vsnprintf(char *buf, size_t size, const char *fmt, va_list ap)
+{
+	char *out = buf;
+	size_t remaining = size ? size : 0;
+	size_t written = 0;
+	if (remaining)
+		*out = '\0';
+	while (*fmt)
+	{
+		if (*fmt != '%')
+		{
+			append_char(&out, &remaining, &written, *fmt++);
+			continue;
+		}
+		fmt++;
+		char spec = *fmt ? *fmt++ : '\0';
+		switch (spec)
+		{
+		case '%':
+			append_char(&out, &remaining, &written, '%');
+			break;
+		case 'c': {
+			char c = (char)va_arg(ap, int);
+			append_char(&out, &remaining, &written, c);
+			break;
+		}
+		case 's':
+			append_string(&out, &remaining, &written, va_arg(ap, const char *));
+			break;
+		case 'd':
+			append_signed(&out, &remaining, &written, va_arg(ap, int));
+			break;
+		case 'u':
+			append_unsigned(&out, &remaining, &written, va_arg(ap, unsigned int), 10, 0);
+			break;
+		case 'x':
+			append_unsigned(&out, &remaining, &written, va_arg(ap, unsigned int), 16, 0);
+			break;
+		case 'X':
+			append_unsigned(&out, &remaining, &written, va_arg(ap, unsigned int), 16, 1);
+			break;
+		default:
+			append_char(&out, &remaining, &written, '%');
+			if (spec)
+				append_char(&out, &remaining, &written, spec);
+			break;
+		}
+	}
+	if (size)
+	{ /* Ensure NUL termination */
+		if (remaining)
+			*out = '\0';
+		else
+			buf[size - 1] = '\0';
+	}
+	return (int)written;
+}
+
+static int clamp_loglevel(int level)
+{
+	if (level < KFS_LOGLEVEL_EMERG)
+		return KFS_LOGLEVEL_EMERG;
+	if (level > KFS_LOGLEVEL_DEBUG)
+		return KFS_LOGLEVEL_DEBUG;
+	return level;
+}
+
+int kfs_snprintf(char *buf, size_t size, const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	int len = kfs_vsnprintf(buf, size, fmt, ap);
+	va_end(ap);
+	return len;
+}
+
+static int vprintk_internal(const char *fmt, va_list ap)
+{
+	const char *msg_fmt = fmt;
+	int level = printk_default_loglevel;
+	int is_cont = 0;
+	while (msg_fmt[0] == '\001')
+	{
+		char code = msg_fmt[1];
+		if (code >= '0' && code <= '7')
+		{
+			level = code - '0';
+			is_cont = 0;
+			msg_fmt += 2;
+			continue;
+		}
+		if (code == 'd')
+		{
+			level = printk_default_loglevel;
+			is_cont = 0;
+			msg_fmt += 2;
+			continue;
+		}
+		if (code == 'c')
+		{
+			is_cont = 1;
+			msg_fmt += 2;
+			break;
+		}
+		break;
+	}
+	char buffer[512];
+	va_list copy;
+	va_copy(copy, ap);
+	int len = kfs_vsnprintf(buffer, sizeof(buffer), msg_fmt, copy);
+	va_end(copy);
+	size_t out_len = (len >= 0 && len < (int)sizeof(buffer)) ? (size_t)len : sizeof(buffer) - 1;
+	int emit = 0;
+	if (is_cont)
+	{
+		if (len >= 0)
+		{
+			level = printk_last_loglevel;
+			emit = printk_last_emitted;
+		}
+	}
+	else
+	{
+		level = clamp_loglevel(level);
+		printk_last_loglevel = level;
+		emit = (level <= printk_console_loglevel);
+	}
+	if (out_len > 0 && emit)
+	{
+		// When the concept of files later emerged, /dev/kmsg would be a natural target for printk output.
+		terminal_write(buffer, out_len);
+		serial_write(buffer, out_len);
+	}
+	if (!is_cont)
+		printk_last_emitted = emit;
+	return len;
+}
+
+int printk(const char *fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	int ret = vprintk_internal(fmt, ap);
+	va_end(ap);
+	return ret;
+}
+
+void kfs_printk_set_console_loglevel(int level)
+{
+	printk_console_loglevel = clamp_loglevel(level);
+}
+
+int kfs_printk_get_console_loglevel(void)
+{
+	return printk_console_loglevel;
+}
+
+int kfs_printk_get_default_loglevel(void)
+{
+	return printk_default_loglevel;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,7 +10,12 @@ LCOV			= lcov --rc lcov_branch_coverage=1
 GENHTML			= genhtml --rc lcov_branch_coverage=1
 # 単体テスト対象ソース: テストコード + テストしたいカーネルコード最小限
 TEST_SRCS		= $(shell find ../test/unit -name '*.c')
-KERNEL_SRCS	= ../init/main.c ../drivers/video/terminal.c ../drivers/char/serial.c ../arch/$(ISA)/abs.c
+KERNEL_SRCS	= ../init/main.c \
+		../drivers/video/terminal.c \
+		../drivers/char/serial.c \
+		../drivers/tty/keyboard.c \
+		../kernel/printk.c \
+		../arch/$(ISA)/abs.c
 UNIT_SRCS		= $(TEST_SRCS) $(KERNEL_SRCS)
 
 # Build & coverage directories

--- a/test/unit/char/serial_io_stub.c
+++ b/test/unit/char/serial_io_stub.c
@@ -1,4 +1,11 @@
+#include <stddef.h>
 #include <stdint.h>
+
+#define STUB_COM1_PORT 0x3F8
+#define STUB_COM1_STATUS (STUB_COM1_PORT + 5)
+#define STUB_PS2_STATUS 0x64
+#define STUB_PS2_DATA 0x60
+
 /* Shared I/O override so multiple test translation units can link */
 struct io_log_entry
 {
@@ -6,16 +13,88 @@ struct io_log_entry
 	uint8_t val;
 	int is_out;
 };
-struct io_log_entry kfs_io_log_entries[1024];
+static const size_t KFS_IO_LOG_CAPACITY = 8192;
+struct io_log_entry kfs_io_log_entries[8192];
 int kfs_io_log_count;
+
+static uint8_t serial_status_seq[64];
+static size_t serial_status_len;
+static size_t serial_status_pos;
+static uint8_t serial_status_default = 0x20;
+
+static uint8_t keyboard_queue[256];
+static size_t keyboard_head;
+static size_t keyboard_tail;
+
+void kfs_stub_reset_io(void)
+{
+	kfs_io_log_count = 0;
+	serial_status_len = 0;
+	serial_status_pos = 0;
+	serial_status_default = 0x20;
+	keyboard_head = 0;
+	keyboard_tail = 0;
+}
+
+void kfs_stub_set_serial_status_sequence(const uint8_t *seq, size_t len, uint8_t default_status)
+{
+	if (!seq)
+	{
+		serial_status_len = 0;
+		serial_status_pos = 0;
+		serial_status_default = default_status;
+		return;
+	}
+	if (len > sizeof(serial_status_seq))
+		len = sizeof(serial_status_seq);
+	for (size_t i = 0; i < len; i++)
+		serial_status_seq[i] = seq[i];
+	serial_status_len = len;
+	serial_status_pos = 0;
+	serial_status_default = default_status;
+}
+
+size_t kfs_stub_serial_status_remaining(void)
+{
+	if (serial_status_pos >= serial_status_len)
+		return 0;
+	return serial_status_len - serial_status_pos;
+}
+
+void kfs_stub_push_keyboard_scancode(uint8_t scancode)
+{
+	if (keyboard_tail < sizeof(keyboard_queue))
+		keyboard_queue[keyboard_tail++] = scancode;
+}
+
+size_t kfs_stub_keyboard_queue_size(void)
+{
+	return keyboard_tail >= keyboard_head ? (keyboard_tail - keyboard_head) : 0;
+}
 
 void kfs_io_outb(uint16_t port, uint8_t val)
 {
-	if (kfs_io_log_count < 1024)
+	if (kfs_io_log_count < (int)KFS_IO_LOG_CAPACITY)
 		kfs_io_log_entries[kfs_io_log_count++] = (struct io_log_entry){port, val, 1};
 }
+
 uint8_t kfs_io_inb(uint16_t port)
 {
-	(void)port;
-	return 0x20;
+	if (port == STUB_COM1_STATUS)
+	{
+		if (serial_status_pos < serial_status_len)
+			return serial_status_seq[serial_status_pos++];
+		return serial_status_default;
+	}
+	if (port == STUB_PS2_STATUS)
+	{
+		return (keyboard_head < keyboard_tail) ? 0x01 : 0x00;
+	}
+	if (port == STUB_PS2_DATA)
+	{
+		if (keyboard_head < keyboard_tail)
+			return keyboard_queue[keyboard_head++];
+		return 0;
+	}
+	return 0;
 }

--- a/test/unit/init/test_kernel_main.c
+++ b/test/unit/init/test_kernel_main.c
@@ -1,6 +1,6 @@
 #include "../support/terminal_test_support.h"
 #include "host_test_framework.h"
-#include <linux/terminal.h>
+#include <kfs/kfs1_bonus.h>
 #include <stdint.h>
 
 /* Provide weak symbol overrides & terminal buffer injection to execute kernel_main */
@@ -18,9 +18,11 @@ KFS_TEST(test_kernel_main_writes_messages)
 {
 	kfs_terminal_set_buffer(term_stub);
 	kernel_main();
-	/* Expect first line begins with '4','2' and second line with 'H','e' of Hello (capital H) */
-	KFS_ASSERT_EQ((long long)cell('4', 7), (long long)term_stub[0]);
-	KFS_ASSERT_EQ((long long)cell('2', 7), (long long)term_stub[1]);
+	uint8_t green = kfs_vga_make_color(VGA_COLOR_LIGHT_GREEN, VGA_COLOR_BLACK);
+	uint8_t normal = kfs_vga_make_color(VGA_COLOR_LIGHT_GREY, VGA_COLOR_BLACK);
+	KFS_ASSERT_EQ((long long)cell('4', green), (long long)term_stub[0]);
+	KFS_ASSERT_EQ((long long)cell('2', green), (long long)term_stub[1]);
+	KFS_ASSERT_EQ((long long)cell('A', normal), (long long)term_stub[KFS_VGA_WIDTH * 1 + 0]);
 }
 
 static struct kfs_test_case cases[] = {

--- a/test/unit/kernel/test_printk.c
+++ b/test/unit/kernel/test_printk.c
@@ -1,0 +1,208 @@
+#include "../support/io_stub_control.h"
+#include "../support/terminal_test_support.h"
+#include "host_test_framework.h"
+#include <kfs/kfs1_bonus.h>
+#include <linux/string.h>
+#include <string.h>
+
+struct io_log_entry
+{
+	uint16_t port;
+	uint8_t val;
+	int is_out;
+};
+extern struct io_log_entry kfs_io_log_entries[];
+extern int kfs_io_log_count;
+
+static void reset_io_log(void)
+{
+	kfs_stub_reset_io();
+	kfs_printk_set_console_loglevel(kfs_printk_get_default_loglevel());
+}
+
+static uint16_t stub[KFS_VGA_WIDTH * KFS_VGA_HEIGHT];
+
+static inline uint16_t make_cell(char c, uint8_t color)
+{
+	return (uint16_t)c | ((uint16_t)color << 8);
+}
+
+static size_t capture_serial(char *dst, size_t max_len)
+{
+	size_t idx = 0;
+	for (int i = 0; i < kfs_io_log_count && idx + 1 < max_len; i++)
+	{
+		if (kfs_io_log_entries[i].port == 0x3F8)
+			dst[idx++] = (char)kfs_io_log_entries[i].val;
+	}
+	dst[idx] = '\0';
+	return idx;
+}
+
+KFS_TEST(test_printk_formats_and_output)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	const char *expected = "value=-42 42 0x2a str Z %";
+	int len = printk("value=%d %u 0x%x %s %c %%", -42, 42u, 0x2au, "str", 'Z');
+	KFS_ASSERT_EQ((long long)strlen(expected), (long long)len);
+	char captured[128];
+	capture_serial(captured, sizeof(captured));
+	for (size_t i = 0; i < strlen(expected); i++)
+	{
+		KFS_ASSERT_EQ((long long)expected[i], (long long)captured[i]);
+		KFS_ASSERT_EQ((long long)make_cell(expected[i], kfs_terminal_get_color()), (long long)stub[i]);
+	}
+}
+
+KFS_TEST(test_printk_percent_without_specifier)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	int len = printk("%");
+	char captured[8];
+	size_t n = capture_serial(captured, sizeof(captured));
+	KFS_ASSERT_EQ(1, (long long)len);
+	KFS_ASSERT_EQ(1, (long long)n);
+	KFS_ASSERT_EQ('%', captured[0]);
+}
+
+KFS_TEST(test_printk_handles_null_string_and_uppercase)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	int len = printk("%s %X %q", (const char *)0, 0x2Au, 0x2Au);
+	char captured[64];
+	size_t n = capture_serial(captured, sizeof(captured));
+	const char *expected = "(null) 2A %q";
+	KFS_ASSERT_EQ((long long)strlen(expected), (long long)n);
+	KFS_ASSERT_EQ((long long)len, (long long)n);
+	for (size_t i = 0; i < strlen(expected); i++)
+		KFS_ASSERT_EQ((long long)expected[i], (long long)captured[i]);
+}
+
+KFS_TEST(test_printk_zero_values_and_empty_message)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	printk("");
+	KFS_ASSERT_EQ(0, kfs_io_log_count);
+	reset_io_log();
+	int len = printk("%d %u %x", 0, 0u, 0u);
+	char captured[32];
+	size_t n = capture_serial(captured, sizeof(captured));
+	const char *expected = "0 0 0";
+	KFS_ASSERT_EQ((long long)strlen(expected), (long long)n);
+	KFS_ASSERT_EQ((long long)len, (long long)n);
+	for (size_t i = 0; i < strlen(expected); i++)
+		KFS_ASSERT_EQ((long long)expected[i], (long long)captured[i]);
+}
+
+KFS_TEST(test_printk_truncates_long_output)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	char payload[600];
+	for (int i = 0; i < 599; i++)
+		payload[i] = 'A';
+	payload[599] = '\0';
+	int len = printk("%s", payload);
+	char captured[520];
+	size_t n = capture_serial(captured, sizeof(captured));
+	KFS_ASSERT_TRUE(kfs_io_log_count > 0);
+	KFS_ASSERT_TRUE(len > 500);
+	KFS_ASSERT_EQ(511, (long long)n);
+	KFS_ASSERT_EQ('A', captured[0]);
+	KFS_ASSERT_EQ('A', captured[510]);
+}
+
+KFS_TEST(test_printk_snprintf_size_zero)
+{
+	char buf[4] = {'x', 'x', 'x', 'x'};
+	int len = kfs_snprintf(buf, 0, "abc");
+	KFS_ASSERT_EQ(3, (long long)len);
+	KFS_ASSERT_EQ('x', buf[0]);
+}
+
+KFS_TEST(test_printk_respects_console_loglevel)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	kfs_printk_set_console_loglevel(KFS_LOGLEVEL_ERR);
+	printk(KERN_INFO "hidden");
+	KFS_ASSERT_EQ(0, kfs_io_log_count);
+	reset_io_log();
+	kfs_printk_set_console_loglevel(KFS_LOGLEVEL_INFO);
+	printk(KERN_ERR "ERR");
+	char captured[16];
+	size_t n = capture_serial(captured, sizeof(captured));
+	KFS_ASSERT_EQ(3, (long long)n);
+	KFS_ASSERT_EQ('E', captured[0]);
+}
+
+KFS_TEST(test_printk_continuation_honours_previous_output)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	kfs_printk_set_console_loglevel(KFS_LOGLEVEL_DEBUG);
+	printk(KERN_INFO "Hello");
+	printk(KERN_CONT " world");
+	char captured[32];
+	size_t n = capture_serial(captured, sizeof(captured));
+	KFS_ASSERT_EQ((long long)strlen("Hello world"), (long long)n);
+	KFS_ASSERT_EQ(0, strncmp("Hello world", captured, n));
+	reset_io_log();
+	kfs_printk_set_console_loglevel(KFS_LOGLEVEL_ERR);
+	printk(KERN_DEBUG "nope");
+	printk(KERN_CONT " tail");
+	KFS_ASSERT_EQ(0, kfs_io_log_count);
+}
+
+KFS_TEST(test_printk_default_loglevel_restored)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+	kfs_printk_set_console_loglevel(KFS_LOGLEVEL_ERR);
+	printk(KERN_DEFAULT "warn");
+	KFS_ASSERT_EQ(0, kfs_io_log_count);
+	reset_io_log();
+	printk(KERN_DEFAULT "warn");
+	KFS_ASSERT_TRUE(kfs_io_log_count > 0);
+}
+
+KFS_TEST(test_printk_clamps_console_loglevel)
+{
+	kfs_printk_set_console_loglevel(-5);
+	KFS_ASSERT_EQ(KFS_LOGLEVEL_EMERG, kfs_printk_get_console_loglevel());
+	kfs_printk_set_console_loglevel(42);
+	KFS_ASSERT_EQ(KFS_LOGLEVEL_DEBUG, kfs_printk_get_console_loglevel());
+	/* restore default */
+	kfs_printk_set_console_loglevel(kfs_printk_get_default_loglevel());
+}
+
+static struct kfs_test_case cases[] = {
+	KFS_REGISTER_TEST(test_printk_formats_and_output),
+	KFS_REGISTER_TEST(test_printk_percent_without_specifier),
+	KFS_REGISTER_TEST(test_printk_handles_null_string_and_uppercase),
+	KFS_REGISTER_TEST(test_printk_zero_values_and_empty_message),
+	KFS_REGISTER_TEST(test_printk_truncates_long_output),
+	KFS_REGISTER_TEST(test_printk_snprintf_size_zero),
+	KFS_REGISTER_TEST(test_printk_respects_console_loglevel),
+	KFS_REGISTER_TEST(test_printk_continuation_honours_previous_output),
+	KFS_REGISTER_TEST(test_printk_default_loglevel_restored),
+	KFS_REGISTER_TEST(test_printk_clamps_console_loglevel),
+};
+
+int register_host_tests_printk(struct kfs_test_case **out)
+{
+	*out = cases;
+	return (int)(sizeof(cases) / sizeof(cases[0]));
+}

--- a/test/unit/support/io_stub_control.h
+++ b/test/unit/support/io_stub_control.h
@@ -1,0 +1,13 @@
+#ifndef KFS_IO_STUB_CONTROL_H
+#define KFS_IO_STUB_CONTROL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+void kfs_stub_reset_io(void);
+void kfs_stub_set_serial_status_sequence(const uint8_t *seq, size_t len, uint8_t default_status);
+size_t kfs_stub_serial_status_remaining(void);
+void kfs_stub_push_keyboard_scancode(uint8_t scancode);
+size_t kfs_stub_keyboard_queue_size(void);
+
+#endif /* KFS_IO_STUB_CONTROL_H */

--- a/test/unit/support/terminal_test_support.h
+++ b/test/unit/support/terminal_test_support.h
@@ -13,8 +13,7 @@ extern uint16_t *kfs_terminal_buffer;
 static inline void kfs_terminal_set_buffer(uint16_t *buf)
 {
 	extern uint16_t *kfs_terminal_buffer; /* redundancy safe */
-	if (buf)
-		kfs_terminal_buffer = buf;
+	kfs_terminal_buffer = buf;
 }
 static inline uint16_t *kfs_terminal_get_buffer(void)
 {

--- a/test/unit/test_registry.c
+++ b/test/unit/test_registry.c
@@ -5,8 +5,11 @@ int register_host_tests_abs(struct kfs_test_case **out);
 int register_host_tests_init_main(struct kfs_test_case **out);
 int register_host_tests_terminal_edge(struct kfs_test_case **out);
 int register_host_tests_terminal_prod(struct kfs_test_case **out);
+int register_host_tests_terminal_bonus(struct kfs_test_case **out);
 int register_host_tests_serial(struct kfs_test_case **out);
 int register_host_tests_kernel_main(struct kfs_test_case **out);
+int register_host_tests_printk(struct kfs_test_case **out);
+int register_host_tests_keyboard(struct kfs_test_case **out);
 
 // すべてのテストケースを一つにまとめる
 static struct kfs_test_case *all_cases = 0;
@@ -25,10 +28,16 @@ int register_host_tests(struct kfs_test_case **out)
 		int count_term_edge = register_host_tests_terminal_edge(&cases_term_edge);
 		struct kfs_test_case *cases_term_prod = 0;
 		int count_term_prod = register_host_tests_terminal_prod(&cases_term_prod);
+		struct kfs_test_case *cases_term_bonus = 0;
+		int count_term_bonus = register_host_tests_terminal_bonus(&cases_term_bonus);
 		struct kfs_test_case *cases_serial = 0;
 		int count_serial = register_host_tests_serial(&cases_serial);
 		struct kfs_test_case *cases_kernel = 0;
 		int count_kernel = register_host_tests_kernel_main(&cases_kernel);
+		struct kfs_test_case *cases_printk = 0;
+		int count_printk = register_host_tests_printk(&cases_printk);
+		struct kfs_test_case *cases_keyboard = 0;
+		int count_keyboard = register_host_tests_keyboard(&cases_keyboard);
 		// 動的確保は避け、静的最大数 (今は少数) を想定してスタック上に置けないので静的配列
 		static struct kfs_test_case merged[64];
 		int idx = 0;
@@ -40,10 +49,16 @@ int register_host_tests(struct kfs_test_case **out)
 			merged[idx++] = cases_term_edge[i];
 		for (int i = 0; i < count_term_prod && idx < 64; i++)
 			merged[idx++] = cases_term_prod[i];
+		for (int i = 0; i < count_term_bonus && idx < 64; i++)
+			merged[idx++] = cases_term_bonus[i];
 		for (int i = 0; i < count_serial && idx < 64; i++)
 			merged[idx++] = cases_serial[i];
 		for (int i = 0; i < count_kernel && idx < 64; i++)
 			merged[idx++] = cases_kernel[i];
+		for (int i = 0; i < count_printk && idx < 64; i++)
+			merged[idx++] = cases_printk[i];
+		for (int i = 0; i < count_keyboard && idx < 64; i++)
+			merged[idx++] = cases_keyboard[i];
 		all_cases = merged;
 		all_count = idx;
 	}

--- a/test/unit/tty/test_keyboard.c
+++ b/test/unit/tty/test_keyboard.c
@@ -1,0 +1,252 @@
+#include "../support/io_stub_control.h"
+#include "../support/terminal_test_support.h"
+#include "host_test_framework.h"
+#include <kfs/kfs1_bonus.h>
+
+static uint16_t stub[KFS_VGA_WIDTH * KFS_VGA_HEIGHT];
+
+static inline uint16_t make_cell(char c, uint8_t color)
+{
+	return (uint16_t)c | ((uint16_t)color << 8);
+}
+
+static void setup_keyboard_common(int call_init)
+{
+	for (size_t i = 0; i < KFS_VGA_WIDTH * KFS_VGA_HEIGHT; i++)
+		stub[i] = 0;
+	kfs_stub_reset_io();
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	for (size_t i = 1; i < KFS_VIRTUAL_CONSOLE_COUNT; i++)
+	{
+		kfs_terminal_switch_console(i);
+		terminal_initialize();
+	}
+	kfs_terminal_switch_console(0);
+	if (call_init)
+	{
+		kfs_keyboard_init();
+	}
+	else
+	{
+		kfs_keyboard_reset();
+	}
+}
+
+static void setup_keyboard(void)
+{
+	setup_keyboard_common(1);
+}
+
+KFS_TEST(test_keyboard_letters_shift_caps)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x1E); /* a */
+	kfs_keyboard_feed_scancode(0x9E);
+	kfs_keyboard_feed_scancode(0x2A); /* shift */
+	kfs_keyboard_feed_scancode(0x1E);
+	kfs_keyboard_feed_scancode(0x9E);
+	kfs_keyboard_feed_scancode(0xAA);
+	kfs_keyboard_feed_scancode(0x3A); /* caps lock */
+	kfs_keyboard_feed_scancode(0x1E);
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell('a', color), (long long)stub[0]);
+	KFS_ASSERT_EQ((long long)make_cell('A', color), (long long)stub[1]);
+	KFS_ASSERT_EQ((long long)make_cell('A', color), (long long)stub[2]);
+}
+
+KFS_TEST(test_keyboard_digits_and_symbols)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x02); /* 1 */
+	kfs_keyboard_feed_scancode(0x82);
+	kfs_keyboard_feed_scancode(0x2A); /* shift */
+	kfs_keyboard_feed_scancode(0x02);
+	kfs_keyboard_feed_scancode(0x82);
+	kfs_keyboard_feed_scancode(0xAA);
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell('1', color), (long long)stub[0]);
+	KFS_ASSERT_EQ((long long)make_cell('!', color), (long long)stub[1]);
+}
+
+KFS_TEST(test_keyboard_right_shift_uppercase)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x36);
+	kfs_keyboard_feed_scancode(0x10); /* q -> uppercase with right shift */
+	kfs_keyboard_feed_scancode(0xB6);
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell('Q', color), (long long)stub[0]);
+}
+
+KFS_TEST(test_keyboard_backspace)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x1E); /* a */
+	kfs_keyboard_feed_scancode(0x30); /* b */
+	kfs_keyboard_feed_scancode(0x2E); /* c */
+	kfs_keyboard_feed_scancode(0x0E); /* backspace */
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)2, (long long)col);
+	KFS_ASSERT_EQ((long long)make_cell(' ', color), (long long)stub[2]);
+}
+
+KFS_TEST(test_keyboard_backspace_previous_row)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x1C); /* enter */
+	kfs_keyboard_feed_scancode(0x9C);
+	kfs_keyboard_feed_scancode(0x0E); /* backspace when row=1 col=0 */
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ(0, (long long)row);
+	KFS_ASSERT_EQ((long long)(KFS_VGA_WIDTH - 1), (long long)col);
+	KFS_ASSERT_EQ((long long)make_cell(' ', color), (long long)stub[(KFS_VGA_WIDTH - 1)]);
+}
+
+KFS_TEST(test_keyboard_alt_function_switch_console)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x0B); /* 0 */
+	kfs_keyboard_feed_scancode(0x8B);
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+	kfs_keyboard_feed_scancode(0x38); /* alt down */
+	kfs_keyboard_feed_scancode(0x3C); /* F2 */
+	kfs_keyboard_feed_scancode(0xBC);
+	kfs_keyboard_feed_scancode(0xB8);
+	KFS_ASSERT_EQ(1, (long long)kfs_terminal_active_console());
+	kfs_keyboard_feed_scancode(0x02); /* 1 */
+	kfs_keyboard_feed_scancode(0x82);
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell('1', color), (long long)stub[0]);
+	kfs_keyboard_feed_scancode(0x38);
+	kfs_keyboard_feed_scancode(0x3B);
+	kfs_keyboard_feed_scancode(0xBB);
+	kfs_keyboard_feed_scancode(0xB8);
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+	KFS_ASSERT_EQ((long long)make_cell('0', color), (long long)stub[0]);
+}
+
+KFS_TEST(test_keyboard_extended_sequence_ignored)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0xE0);
+	kfs_keyboard_feed_scancode(0x50);
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	KFS_ASSERT_EQ(0, (long long)row);
+	KFS_ASSERT_EQ(0, (long long)col);
+}
+
+KFS_TEST(test_keyboard_unknown_key_is_ignored)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x3F); /* F5 (no mapping) */
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	KFS_ASSERT_EQ(0, (long long)row);
+	KFS_ASSERT_EQ(0, (long long)col);
+}
+
+KFS_TEST(test_keyboard_shift_nonmapped_falls_back)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x2A);
+	kfs_keyboard_feed_scancode(0x0F); /* tab */
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell('\t', color), (long long)stub[0]);
+	kfs_keyboard_feed_scancode(0xAA);
+}
+
+KFS_TEST(test_keyboard_alt_function_out_of_range)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x38);
+	kfs_keyboard_feed_scancode(0x3F); /* F5 -> target 4 which is >= count */
+	kfs_keyboard_feed_scancode(0xBF);
+	kfs_keyboard_feed_scancode(0xB8);
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+}
+
+KFS_TEST(test_keyboard_extended_e1_sequence)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0xE1);
+	kfs_keyboard_feed_scancode(0x1D);
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	KFS_ASSERT_EQ(0, (long long)row);
+	KFS_ASSERT_EQ(0, (long long)col);
+}
+
+KFS_TEST(test_keyboard_backspace_at_origin_noop)
+{
+	setup_keyboard();
+	kfs_keyboard_feed_scancode(0x0E);
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	KFS_ASSERT_EQ(0, (long long)row);
+	KFS_ASSERT_EQ(0, (long long)col);
+}
+
+KFS_TEST(test_keyboard_init_drains_pending_scancodes)
+{
+	setup_keyboard_common(0);
+	kfs_stub_push_keyboard_scancode(0x1E);
+	kfs_stub_push_keyboard_scancode(0x9E);
+	KFS_ASSERT_EQ(2, (long long)kfs_stub_keyboard_queue_size());
+	kfs_keyboard_init();
+	KFS_ASSERT_EQ(0, (long long)kfs_stub_keyboard_queue_size());
+}
+
+KFS_TEST(test_keyboard_poll_requires_initialization)
+{
+	setup_keyboard_common(0);
+	kfs_stub_push_keyboard_scancode(0x1E);
+	kfs_keyboard_poll();
+	KFS_ASSERT_EQ(1, (long long)kfs_stub_keyboard_queue_size());
+}
+
+KFS_TEST(test_keyboard_poll_consumes_queue)
+{
+	setup_keyboard();
+	kfs_stub_push_keyboard_scancode(0x1E);
+	kfs_stub_push_keyboard_scancode(0x9E);
+	kfs_keyboard_poll();
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell('a', color), (long long)stub[0]);
+	KFS_ASSERT_EQ(0, (long long)kfs_stub_keyboard_queue_size());
+}
+
+static struct kfs_test_case cases[] = {
+	KFS_REGISTER_TEST(test_keyboard_poll_requires_initialization),
+	KFS_REGISTER_TEST(test_keyboard_init_drains_pending_scancodes),
+	KFS_REGISTER_TEST(test_keyboard_letters_shift_caps),
+	KFS_REGISTER_TEST(test_keyboard_digits_and_symbols),
+	KFS_REGISTER_TEST(test_keyboard_backspace),
+	KFS_REGISTER_TEST(test_keyboard_alt_function_switch_console),
+	KFS_REGISTER_TEST(test_keyboard_backspace_previous_row),
+	KFS_REGISTER_TEST(test_keyboard_extended_sequence_ignored),
+	KFS_REGISTER_TEST(test_keyboard_poll_consumes_queue),
+	KFS_REGISTER_TEST(test_keyboard_right_shift_uppercase),
+	KFS_REGISTER_TEST(test_keyboard_unknown_key_is_ignored),
+	KFS_REGISTER_TEST(test_keyboard_shift_nonmapped_falls_back),
+	KFS_REGISTER_TEST(test_keyboard_alt_function_out_of_range),
+	KFS_REGISTER_TEST(test_keyboard_extended_e1_sequence),
+	KFS_REGISTER_TEST(test_keyboard_backspace_at_origin_noop),
+};
+
+int register_host_tests_keyboard(struct kfs_test_case **out)
+{
+	*out = cases;
+	return (int)(sizeof(cases) / sizeof(cases[0]));
+}

--- a/test/unit/video/test_terminal_bonus.c
+++ b/test/unit/video/test_terminal_bonus.c
@@ -1,0 +1,153 @@
+#include "../support/terminal_test_support.h"
+#include "host_test_framework.h"
+#include <kfs/kfs1_bonus.h>
+#include <stdint.h>
+
+struct io_log_entry
+{
+	uint16_t port;
+	uint8_t val;
+	int is_out;
+};
+extern struct io_log_entry kfs_io_log_entries[];
+extern int kfs_io_log_count;
+
+static void reset_io_log(void)
+{
+	kfs_io_log_count = 0;
+}
+
+static uint16_t stub[KFS_VGA_WIDTH * KFS_VGA_HEIGHT];
+
+static inline uint16_t make_cell(char c, uint8_t color)
+{
+	return (uint16_t)c | ((uint16_t)color << 8);
+}
+
+static void setup_terminal(void)
+{
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+	reset_io_log();
+}
+
+KFS_TEST(test_vga_color_helpers)
+{
+	setup_terminal();
+	uint8_t color = kfs_vga_make_color(VGA_COLOR_RED, VGA_COLOR_BLUE);
+	KFS_ASSERT_EQ((long long)((VGA_COLOR_RED) | (VGA_COLOR_BLUE << 4)), (long long)color);
+	uint16_t entry = kfs_vga_make_entry('X', color);
+	KFS_ASSERT_EQ((long long)(((uint16_t)'X') | ((uint16_t)color << 8)), (long long)entry);
+	kfs_terminal_set_color(color);
+	KFS_ASSERT_EQ((long long)color, (long long)kfs_terminal_get_color());
+}
+
+KFS_TEST(test_cursor_movement_updates_hw)
+{
+	setup_terminal();
+	int start = kfs_io_log_count;
+	kfs_terminal_move_cursor(3, 5);
+	KFS_ASSERT_EQ((long long)(start + 4), (long long)kfs_io_log_count);
+	uint16_t pos = (uint16_t)(3 * KFS_VGA_WIDTH + 5);
+	KFS_ASSERT_EQ(0x3D4, (long long)kfs_io_log_entries[start + 0].port);
+	KFS_ASSERT_EQ(0x0F, (long long)kfs_io_log_entries[start + 0].val);
+	KFS_ASSERT_EQ(0x3D5, (long long)kfs_io_log_entries[start + 1].port);
+	KFS_ASSERT_EQ((long long)(pos & 0xFF), (long long)kfs_io_log_entries[start + 1].val);
+	KFS_ASSERT_EQ(0x3D4, (long long)kfs_io_log_entries[start + 2].port);
+	KFS_ASSERT_EQ(0x0E, (long long)kfs_io_log_entries[start + 2].val);
+	KFS_ASSERT_EQ(0x3D5, (long long)kfs_io_log_entries[start + 3].port);
+	KFS_ASSERT_EQ((long long)((pos >> 8) & 0xFF), (long long)kfs_io_log_entries[start + 3].val);
+}
+
+KFS_TEST(test_virtual_console_switching_preserves_buffers)
+{
+	setup_terminal();
+	terminal_writestring("A");
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+	kfs_terminal_switch_console(1);
+	KFS_ASSERT_EQ(1, (long long)kfs_terminal_active_console());
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell(' ', color), (long long)stub[0]);
+	terminal_putchar('Z');
+	KFS_ASSERT_EQ((long long)make_cell('Z', color), (long long)stub[0]);
+	kfs_terminal_switch_console(0);
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+	KFS_ASSERT_EQ((long long)make_cell('A', kfs_terminal_get_color()), (long long)stub[0]);
+	kfs_terminal_switch_console(5);
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+	KFS_ASSERT_EQ((long long)KFS_VIRTUAL_CONSOLE_COUNT, (long long)kfs_terminal_console_count());
+}
+
+KFS_TEST(test_terminal_null_buffer_paths)
+{
+	setup_terminal();
+	kfs_terminal_set_buffer(NULL);
+	terminal_putchar('Z');
+	kfs_terminal_switch_console(1);
+	kfs_terminal_switch_console(0);
+	kfs_terminal_set_buffer(stub);
+	terminal_initialize();
+}
+
+KFS_TEST(test_terminal_move_cursor_clamps)
+{
+	setup_terminal();
+	kfs_terminal_move_cursor(KFS_VGA_HEIGHT + 4, KFS_VGA_WIDTH + 5);
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	KFS_ASSERT_EQ((long long)(KFS_VGA_HEIGHT - 1), (long long)row);
+	KFS_ASSERT_EQ((long long)(KFS_VGA_WIDTH - 1), (long long)col);
+}
+
+KFS_TEST(test_terminal_get_cursor_null_ignored)
+{
+	setup_terminal();
+	kfs_terminal_get_cursor(NULL, NULL);
+	/* Expect no crash and cursor unchanged */
+	size_t row = 0;
+	size_t col = 0;
+	kfs_terminal_get_cursor(&row, &col);
+	KFS_ASSERT_EQ(0, (long long)row);
+	KFS_ASSERT_EQ(0, (long long)col);
+}
+
+KFS_TEST(test_terminal_switch_console_out_of_range)
+{
+	setup_terminal();
+	kfs_terminal_switch_console(KFS_VIRTUAL_CONSOLE_COUNT);
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+}
+
+KFS_TEST(test_terminal_switch_same_console_noop)
+{
+	setup_terminal();
+	kfs_terminal_switch_console(0);
+	KFS_ASSERT_EQ(0, (long long)kfs_terminal_active_console());
+}
+
+KFS_TEST(test_terminal_write_tab_with_shift)
+{
+	setup_terminal();
+	terminal_putchar('\t');
+	uint8_t color = kfs_terminal_get_color();
+	KFS_ASSERT_EQ((long long)make_cell('\t', color), (long long)stub[0]);
+}
+
+static struct kfs_test_case cases[] = {
+	KFS_REGISTER_TEST(test_vga_color_helpers),
+	KFS_REGISTER_TEST(test_cursor_movement_updates_hw),
+	KFS_REGISTER_TEST(test_virtual_console_switching_preserves_buffers),
+	KFS_REGISTER_TEST(test_terminal_null_buffer_paths),
+	KFS_REGISTER_TEST(test_terminal_move_cursor_clamps),
+	KFS_REGISTER_TEST(test_terminal_get_cursor_null_ignored),
+	KFS_REGISTER_TEST(test_terminal_switch_console_out_of_range),
+	KFS_REGISTER_TEST(test_terminal_switch_same_console_noop),
+	KFS_REGISTER_TEST(test_terminal_write_tab_with_shift),
+};
+
+int register_host_tests_terminal_bonus(struct kfs_test_case **out)
+{
+	*out = cases;
+	return (int)(sizeof(cases) / sizeof(cases[0]));
+}


### PR DESCRIPTION
#55


## Summary
This pull request introduces a major enhancement to the kernel by adding support for keyboard input and multi-console terminal switching. It refactors and extends the terminal and printk subsystems, providing new APIs for keyboard handling, virtual consoles, and formatted logging. The changes improve modularity, testability, and user interaction, including Alt+F1..F4 console switching and real-time keyboard echo.

**Keyboard and Console Features:**

* Added a new keyboard driver (`drivers/tty/keyboard.c`) with scancode translation, modifier key handling (shift, alt, caps lock), backspace support, and integration with the terminal for character echoing and console switching via Alt+F1..F4.
* Refactored terminal logic in `drivers/video/terminal.c` to support multiple virtual consoles, cursor management, color settings, and switching between consoles. New APIs allow external modules to control cursor position, color, and active console.

**Kernel Logging and Printk:**

* Implemented a custom `printk` subsystem in `kernel/printk.c` with configurable log levels, formatted output, and integration with both the terminal and serial output. Includes new functions for setting/getting log levels and formatting strings.

**Public Kernel API:**

* Introduced `include/kfs/kfs1_bonus.h` to expose new kernel APIs for terminal, keyboard, and printk functionality, including constants for VGA dimensions and console count.

**Integration and Testing:**

* Updated `init/main.c` to initialize the keyboard and terminal subsystems, set colors, display usage hints, and continuously poll for keyboard input.
* Enhanced unit test support by updating `test/Makefile` to include new source files and expanding the serial I/O stub in `test/unit/char/serial_io_stub.c` to simulate keyboard and serial hardware for testing. [[1]](diffhunk://#diff-740cb5a1689091cb894445e46683c255e39689ccba1c6c63d8a8841c8df8817dL13-R18) [[2]](diffhunk://#diff-182028e92710b4f8384b0bc0abe08a647e24843ae3504bea5ccb0807915407fdR1-R99)

**Documentation and Comments:**

* Added clarifying comments to low-level I/O routines in `drivers/char/serial.c` to explain port access for PS/2 keyboard input.
