### PR TITLE
Fr/#64/define the main functions in stringh

### DIFF
--- a/include/linux/string.h
+++ b/include/linux/string.h
@@ -1,19 +1,72 @@
-/* Minimal string helpers (subset) */
-#ifndef LINUX_STRING_H
-#define LINUX_STRING_H
+#ifndef _STRING_H_
+#define _STRING_H_
 
 #include <stddef.h>
 
-#ifdef __cplusplus
-extern "C"
-{
+#ifndef __KERNEL_SIZE_T_DEFINED
+typedef size_t __kernel_size_t;
+#define __KERNEL_SIZE_T_DEFINED
 #endif
 
-	char *strcpy(char *dst, const char *src);
-	size_t strlen(const char *s);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __HAVE_ARCH_STRCPY
+char *strcpy(char *dst, const char *src);
+#endif
+#ifndef __HAVE_ARCH_STRNCPY
+char *strncpy(char *dst, const char *src, __kernel_size_t count);
+#endif
+#ifndef __HAVE_ARCH_STRLCPY
+__kernel_size_t strlcpy(char *dst, const char *src, __kernel_size_t size);
+#endif
+#ifndef __HAVE_ARCH_STRCAT
+char *strcat(char *dst, const char *src);
+#endif
+#ifndef __HAVE_ARCH_STRNCAT
+char *strncat(char *dst, const char *src, __kernel_size_t count);
+#endif
+#ifndef __HAVE_ARCH_STRCMP
+int strcmp(const char *lhs, const char *rhs);
+#endif
+#ifndef __HAVE_ARCH_STRNCMP
+int strncmp(const char *lhs, const char *rhs, __kernel_size_t count);
+#endif
+#ifndef __HAVE_ARCH_STRCHR
+char *strchr(const char *str, int ch);
+#endif
+#ifndef __HAVE_ARCH_STRRCHR
+char *strrchr(const char *str, int ch);
+#endif
+#ifndef __HAVE_ARCH_STRSTR
+char *strstr(const char *haystack, const char *needle);
+#endif
+#ifndef __HAVE_ARCH_STRLEN
+__kernel_size_t strlen(const char *s);
+#endif
+#ifndef __HAVE_ARCH_STRNLEN
+__kernel_size_t strnlen(const char *s, __kernel_size_t maxlen);
+#endif
+
+#ifndef __HAVE_ARCH_MEMSET
+void *memset(void *dst, int value, __kernel_size_t count);
+#endif
+#ifndef __HAVE_ARCH_MEMCPY
+void *memcpy(void *dst, const void *src, __kernel_size_t count);
+#endif
+#ifndef __HAVE_ARCH_MEMMOVE
+void *memmove(void *dst, const void *src, __kernel_size_t count);
+#endif
+#ifndef __HAVE_ARCH_MEMCMP
+int memcmp(const void *lhs, const void *rhs, __kernel_size_t count);
+#endif
+#ifndef __HAVE_ARCH_MEMCHR
+void *memchr(const void *ptr, int ch, __kernel_size_t count);
+#endif
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* LINUX_STRING_H */
+#endif /* _STRING_H_ */

--- a/include/linux/string.h
+++ b/include/linux/string.h
@@ -9,60 +9,61 @@ typedef size_t __kernel_size_t;
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #ifndef __HAVE_ARCH_STRCPY
-char *strcpy(char *dst, const char *src);
+	char *strcpy(char *dst, const char *src);
 #endif
 #ifndef __HAVE_ARCH_STRNCPY
-char *strncpy(char *dst, const char *src, __kernel_size_t count);
+	char *strncpy(char *dst, const char *src, __kernel_size_t count);
 #endif
 #ifndef __HAVE_ARCH_STRLCPY
-__kernel_size_t strlcpy(char *dst, const char *src, __kernel_size_t size);
+	__kernel_size_t strlcpy(char *dst, const char *src, __kernel_size_t size);
 #endif
 #ifndef __HAVE_ARCH_STRCAT
-char *strcat(char *dst, const char *src);
+	char *strcat(char *dst, const char *src);
 #endif
 #ifndef __HAVE_ARCH_STRNCAT
-char *strncat(char *dst, const char *src, __kernel_size_t count);
+	char *strncat(char *dst, const char *src, __kernel_size_t count);
 #endif
 #ifndef __HAVE_ARCH_STRCMP
-int strcmp(const char *lhs, const char *rhs);
+	int strcmp(const char *lhs, const char *rhs);
 #endif
 #ifndef __HAVE_ARCH_STRNCMP
-int strncmp(const char *lhs, const char *rhs, __kernel_size_t count);
+	int strncmp(const char *lhs, const char *rhs, __kernel_size_t count);
 #endif
 #ifndef __HAVE_ARCH_STRCHR
-char *strchr(const char *str, int ch);
+	char *strchr(const char *str, int ch);
 #endif
 #ifndef __HAVE_ARCH_STRRCHR
-char *strrchr(const char *str, int ch);
+	char *strrchr(const char *str, int ch);
 #endif
 #ifndef __HAVE_ARCH_STRSTR
-char *strstr(const char *haystack, const char *needle);
+	char *strstr(const char *haystack, const char *needle);
 #endif
 #ifndef __HAVE_ARCH_STRLEN
-__kernel_size_t strlen(const char *s);
+	__kernel_size_t strlen(const char *s);
 #endif
 #ifndef __HAVE_ARCH_STRNLEN
-__kernel_size_t strnlen(const char *s, __kernel_size_t maxlen);
+	__kernel_size_t strnlen(const char *s, __kernel_size_t maxlen);
 #endif
 
 #ifndef __HAVE_ARCH_MEMSET
-void *memset(void *dst, int value, __kernel_size_t count);
+	void *memset(void *dst, int value, __kernel_size_t count);
 #endif
 #ifndef __HAVE_ARCH_MEMCPY
-void *memcpy(void *dst, const void *src, __kernel_size_t count);
+	void *memcpy(void *dst, const void *src, __kernel_size_t count);
 #endif
 #ifndef __HAVE_ARCH_MEMMOVE
-void *memmove(void *dst, const void *src, __kernel_size_t count);
+	void *memmove(void *dst, const void *src, __kernel_size_t count);
 #endif
 #ifndef __HAVE_ARCH_MEMCMP
-int memcmp(const void *lhs, const void *rhs, __kernel_size_t count);
+	int memcmp(const void *lhs, const void *rhs, __kernel_size_t count);
 #endif
 #ifndef __HAVE_ARCH_MEMCHR
-void *memchr(const void *ptr, int ch, __kernel_size_t count);
+	void *memchr(const void *ptr, int ch, __kernel_size_t count);
 #endif
 
 #ifdef __cplusplus

--- a/lib/string.c
+++ b/lib/string.c
@@ -1,15 +1,17 @@
-/* Minimal string helpers modelled after early Linux kernel style.
- * Only the subset we currently need is provided.
- * Notes:
- *  - No special handling for overlapping regions (UB mirrors standard libc)
- *  - Keep implementations simple and inline-friendly for -O2.
- */
 #include <linux/string.h>
 
 size_t strlen(const char *s)
 {
 	const char *p = s;
 	while (*p)
+		p++;
+	return (size_t)(p - s);
+}
+
+size_t strnlen(const char *s, size_t maxlen)
+{
+	const char *p = s;
+	while (maxlen-- && *p)
 		p++;
 	return (size_t)(p - s);
 }
@@ -21,4 +23,188 @@ char *strcpy(char *dst, const char *src)
 	{ /* copy including final NUL */
 	}
 	return ret;
+}
+
+char *strncpy(char *dst, const char *src, size_t count)
+{
+	char *ret = dst;
+	while (count && *src)
+	{
+		*dst++ = *src++;
+		count--;
+	}
+	while (count--)
+		*dst++ = '\0';
+	return ret;
+}
+
+size_t strlcpy(char *dst, const char *src, size_t size)
+{
+	size_t len = strlen(src);
+	if (size)
+	{
+		size_t copy = (len >= size) ? size - 1 : len;
+		for (size_t i = 0; i < copy; i++)
+			dst[i] = src[i];
+		dst[copy] = '\0';
+	}
+	return len;
+}
+
+char *strcat(char *dst, const char *src)
+{
+	char *ret = dst;
+	while (*dst)
+		dst++;
+	while ((*dst++ = *src++))
+	{
+	}
+	return ret;
+}
+
+char *strncat(char *dst, const char *src, size_t count)
+{
+	char *ret = dst;
+	while (*dst)
+		dst++;
+	if (!count)
+		return ret;
+	while (count-- && *src)
+		*dst++ = *src++;
+	*dst = '\0';
+	return ret;
+}
+
+int strcmp(const char *lhs, const char *rhs)
+{
+	while (*lhs && (*lhs == *rhs))
+	{
+		lhs++;
+		rhs++;
+	}
+	return (unsigned char)*lhs - (unsigned char)*rhs;
+}
+
+int strncmp(const char *lhs, const char *rhs, size_t count)
+{
+	while (count && *lhs && (*lhs == *rhs))
+	{
+		lhs++;
+		rhs++;
+		count--;
+	}
+	if (!count)
+		return 0;
+	return (unsigned char)*lhs - (unsigned char)*rhs;
+}
+
+char *strchr(const char *str, int ch)
+{
+	char c = (char)ch;
+	for (;; str++)
+	{
+		if (*str == c)
+			return (char *)str;
+		if (*str == '\0')
+			return NULL;
+	}
+}
+
+char *strrchr(const char *str, int ch)
+{
+	char c = (char)ch;
+	const char *last = NULL;
+	for (;; str++)
+	{
+		if (*str == c)
+			last = str;
+		if (*str == '\0')
+			break;
+	}
+	return (char *)last;
+}
+
+char *strstr(const char *haystack, const char *needle)
+{
+	if (!*needle)
+		return (char *)haystack;
+	for (const char *h = haystack; *h; h++)
+	{
+		if (*h != *needle)
+			continue;
+		const char *p = h + 1;
+		const char *q = needle + 1;
+		while (*p && *q && *p == *q)
+		{
+			p++;
+			q++;
+		}
+		if (!*q)
+			return (char *)h;
+	}
+	return NULL;
+}
+
+void *memset(void *dst, int value, size_t count)
+{
+	unsigned char *p = (unsigned char *)dst;
+	unsigned char val = (unsigned char)value;
+	while (count--)
+		*p++ = val;
+	return dst;
+}
+
+void *memcpy(void *dst, const void *src, size_t count)
+{
+	unsigned char *d = (unsigned char *)dst;
+	const unsigned char *s = (const unsigned char *)src;
+	while (count--)
+		*d++ = *s++;
+	return dst;
+}
+
+void *memmove(void *dst, const void *src, size_t count)
+{
+	unsigned char *d = (unsigned char *)dst;
+	const unsigned char *s = (const unsigned char *)src;
+	if (d == s || count == 0)
+		return dst;
+	if (d < s)
+	{
+		while (count--)
+			*d++ = *s++;
+	}
+	else
+	{
+		while (count--)
+			d[count] = s[count];
+	}
+	return dst;
+}
+
+int memcmp(const void *lhs, const void *rhs, size_t count)
+{
+	const unsigned char *a = (const unsigned char *)lhs;
+	const unsigned char *b = (const unsigned char *)rhs;
+	while (count--)
+	{
+		unsigned char va = *a++;
+		unsigned char vb = *b++;
+		if (va != vb)
+			return (int)va - (int)vb;
+	}
+	return 0;
+}
+
+void *memchr(const void *ptr, int ch, size_t count)
+{
+	const unsigned char *p = (const unsigned char *)ptr;
+	unsigned char target = (unsigned char)ch;
+	while (count--)
+	{
+		if (*p == target)
+			return (void *)p;
+		p++;
+	}
+	return NULL;
 }

--- a/test/unit/lib/test_string.c
+++ b/test/unit/lib/test_string.c
@@ -1,0 +1,159 @@
+#include "host_test_framework.h"
+#include <linux/string.h>
+
+static char *(*volatile kfs_strcat_fn)(char *, const char *) = strcat;
+static char *(*volatile kfs_strncat_fn)(char *, const char *, size_t) = strncat;
+static char *(*volatile kfs_strncpy_fn)(char *, const char *, size_t) = strncpy;
+static void *(*volatile kfs_memcpy_fn)(void *, const void *, size_t) = memcpy;
+static void *(*volatile kfs_memmove_fn)(void *, const void *, size_t) = memmove;
+static void *(*volatile kfs_memset_fn)(void *, int, size_t) = memset;
+static int (*volatile kfs_strncmp_fn)(const char *, const char *, size_t) = strncmp;
+static char *(*volatile kfs_strstr_fn)(const char *, const char *) = strstr;
+
+KFS_TEST(test_strnlen_clamps)
+{
+	const char *text = "hello";
+	KFS_ASSERT_EQ(5, (long long)strnlen(text, 16));
+	KFS_ASSERT_EQ(3, (long long)strnlen(text, 3));
+}
+
+KFS_TEST(test_strncpy_pads_with_nuls)
+{
+	char buf[8];
+	char *ret = kfs_strncpy_fn(buf, "abc", sizeof(buf));
+	KFS_ASSERT_TRUE(ret == buf);
+	KFS_ASSERT_TRUE(strcmp(buf, "abc") == 0);
+	for (size_t i = 4; i < sizeof(buf); i++)
+		KFS_ASSERT_EQ(0, (long long)buf[i]);
+	char partial[4] = {0};
+	kfs_strncpy_fn(partial, "abcdef", 2);
+	KFS_ASSERT_TRUE(partial[0] == 'a');
+	KFS_ASSERT_TRUE(partial[1] == 'b');
+	KFS_ASSERT_EQ(0, (long long)partial[2]);
+}
+
+KFS_TEST(test_strncpy_zero_count)
+{
+	char buf[] = "keep";
+	char *ret = kfs_strncpy_fn(buf, "data", 0);
+	KFS_ASSERT_TRUE(ret == buf);
+	KFS_ASSERT_TRUE(strcmp(buf, "keep") == 0);
+}
+
+KFS_TEST(test_strlcpy_behaviour)
+{
+	char buf[5];
+	size_t copied = strlcpy(buf, "world", sizeof(buf));
+	KFS_ASSERT_EQ(5, (long long)copied);
+	KFS_ASSERT_TRUE(strcmp(buf, "worl") == 0);
+
+	char guard[3] = {'X', 'Y', '\0'};
+	size_t only_len = strlcpy(guard, "hi", 0);
+	KFS_ASSERT_EQ(2, (long long)only_len);
+	KFS_ASSERT_EQ('X', (long long)guard[0]);
+
+	char roomy[8];
+	size_t len2 = strlcpy(roomy, "hi", sizeof(roomy));
+	KFS_ASSERT_EQ(2, (long long)len2);
+	KFS_ASSERT_TRUE(strcmp(roomy, "hi") == 0);
+}
+
+KFS_TEST(test_strcat_and_strncat)
+{
+	char buf[16] = "foo";
+	KFS_ASSERT_TRUE(kfs_strcat_fn(buf, "bar") == buf);
+	KFS_ASSERT_TRUE(strcmp(buf, "foobar") == 0);
+	KFS_ASSERT_TRUE(kfs_strncat_fn(buf, "bazqux", 3) == buf);
+	KFS_ASSERT_TRUE(strcmp(buf, "foobarbaz") == 0);
+	KFS_ASSERT_TRUE(kfs_strncat_fn(buf, "ignored", 0) == buf);
+	KFS_ASSERT_TRUE(strcmp(buf, "foobarbaz") == 0);
+	char limited[16] = "foo";
+	KFS_ASSERT_TRUE(kfs_strncat_fn(limited, "bar", 2) == limited);
+	KFS_ASSERT_TRUE(strcmp(limited, "fooba") == 0);
+	char full[16] = "foo";
+	KFS_ASSERT_TRUE(kfs_strncat_fn(full, "bar", 10) == full);
+	KFS_ASSERT_TRUE(strcmp(full, "foobar") == 0);
+}
+
+KFS_TEST(test_strcmp_family)
+{
+	KFS_ASSERT_TRUE(strcmp("abc", "abc") == 0);
+	KFS_ASSERT_TRUE(strcmp("abc", "abd") < 0);
+	KFS_ASSERT_TRUE(strcmp("abd", "abc") > 0);
+	KFS_ASSERT_TRUE(strcmp("", "foo") < 0);
+	KFS_ASSERT_TRUE(kfs_strncmp_fn("alphabet", "alpha", 5) == 0);
+	KFS_ASSERT_TRUE(kfs_strncmp_fn("alpha", "alphabet", 7) < 0);
+	KFS_ASSERT_TRUE(kfs_strncmp_fn("abc", "abd", 3) < 0);
+	KFS_ASSERT_TRUE(kfs_strncmp_fn("abc", "xyz", 0) == 0);
+}
+
+KFS_TEST(test_strchr_strrchr_strstr)
+{
+	const char *sample = "abracadabra";
+	KFS_ASSERT_TRUE(strchr(sample, 'r') == sample + 2);
+	KFS_ASSERT_TRUE(strrchr(sample, 'r') == sample + 9);
+	KFS_ASSERT_TRUE(kfs_strstr_fn(sample, "cada") == sample + 4);
+	KFS_ASSERT_TRUE(kfs_strstr_fn(sample, "") == sample);
+	KFS_ASSERT_TRUE(strchr(sample, 'z') == 0);
+	KFS_ASSERT_TRUE(kfs_strstr_fn(sample, "xyz") == 0);
+	KFS_ASSERT_TRUE(kfs_strstr_fn("abcdef", "abz") == 0);
+	KFS_ASSERT_TRUE(kfs_strstr_fn("ab", "abc") == 0);
+}
+
+KFS_TEST(test_memset_and_memcpy)
+{
+	unsigned char buf[6];
+	kfs_memset_fn(buf, 0xAB, sizeof(buf));
+	for (size_t i = 0; i < sizeof(buf); i++)
+		KFS_ASSERT_EQ(0xAB, (long long)buf[i]);
+	unsigned char other[6] = {0};
+	kfs_memcpy_fn(other, buf, sizeof(buf));
+	for (size_t i = 0; i < sizeof(buf); i++)
+		KFS_ASSERT_EQ((long long)buf[i], (long long)other[i]);
+}
+
+KFS_TEST(test_memmove_handles_overlap)
+{
+	char text[16] = "abcdef";
+	kfs_memmove_fn(text + 2, text, 4);
+	KFS_ASSERT_TRUE(strcmp(text, "ababcd") == 0);
+	kfs_memmove_fn(text, text + 2, 4);
+	KFS_ASSERT_TRUE(strcmp(text, "abcdcd") == 0);
+	kfs_memmove_fn(text, text, 3);
+	KFS_ASSERT_TRUE(strcmp(text, "abcdcd") == 0);
+	kfs_memmove_fn(text, text + 1, 0);
+	KFS_ASSERT_TRUE(strcmp(text, "abcdcd") == 0);
+	kfs_memmove_fn(text, text + 2, 2);
+	KFS_ASSERT_TRUE(strncmp(text, "cd", 2) == 0);
+}
+
+KFS_TEST(test_memcmp_and_memchr)
+{
+	unsigned char lhs[] = {1, 2, 3, 4};
+	unsigned char rhs[] = {1, 2, 3, 5};
+	KFS_ASSERT_TRUE(memcmp(lhs, rhs, 3) == 0);
+	KFS_ASSERT_TRUE(memcmp(lhs, rhs, 4) < 0);
+	unsigned char data[] = {0, 1, 2, 3, 4};
+	void *found = memchr(data, 2, sizeof(data));
+	KFS_ASSERT_TRUE(found == &data[2]);
+	KFS_ASSERT_TRUE(memchr(data, 9, sizeof(data)) == 0);
+}
+
+static struct kfs_test_case cases[] = {
+	KFS_REGISTER_TEST(test_strnlen_clamps),
+	KFS_REGISTER_TEST(test_strncpy_pads_with_nuls),
+	KFS_REGISTER_TEST(test_strncpy_zero_count),
+	KFS_REGISTER_TEST(test_strlcpy_behaviour),
+	KFS_REGISTER_TEST(test_strcat_and_strncat),
+	KFS_REGISTER_TEST(test_strcmp_family),
+	KFS_REGISTER_TEST(test_strchr_strrchr_strstr),
+	KFS_REGISTER_TEST(test_memset_and_memcpy),
+	KFS_REGISTER_TEST(test_memmove_handles_overlap),
+	KFS_REGISTER_TEST(test_memcmp_and_memchr),
+};
+
+int register_host_tests_string(struct kfs_test_case **out)
+{
+	*out = cases;
+	return (int)(sizeof(cases) / sizeof(cases[0]));
+}

--- a/test/unit/lib/test_string.c
+++ b/test/unit/lib/test_string.c
@@ -140,16 +140,11 @@ KFS_TEST(test_memcmp_and_memchr)
 }
 
 static struct kfs_test_case cases[] = {
-	KFS_REGISTER_TEST(test_strnlen_clamps),
-	KFS_REGISTER_TEST(test_strncpy_pads_with_nuls),
-	KFS_REGISTER_TEST(test_strncpy_zero_count),
-	KFS_REGISTER_TEST(test_strlcpy_behaviour),
-	KFS_REGISTER_TEST(test_strcat_and_strncat),
-	KFS_REGISTER_TEST(test_strcmp_family),
-	KFS_REGISTER_TEST(test_strchr_strrchr_strstr),
-	KFS_REGISTER_TEST(test_memset_and_memcpy),
-	KFS_REGISTER_TEST(test_memmove_handles_overlap),
-	KFS_REGISTER_TEST(test_memcmp_and_memchr),
+	KFS_REGISTER_TEST(test_strnlen_clamps),			 KFS_REGISTER_TEST(test_strncpy_pads_with_nuls),
+	KFS_REGISTER_TEST(test_strncpy_zero_count),		 KFS_REGISTER_TEST(test_strlcpy_behaviour),
+	KFS_REGISTER_TEST(test_strcat_and_strncat),		 KFS_REGISTER_TEST(test_strcmp_family),
+	KFS_REGISTER_TEST(test_strchr_strrchr_strstr),	 KFS_REGISTER_TEST(test_memset_and_memcpy),
+	KFS_REGISTER_TEST(test_memmove_handles_overlap), KFS_REGISTER_TEST(test_memcmp_and_memchr),
 };
 
 int register_host_tests_string(struct kfs_test_case **out)

--- a/test/unit/test_registry.c
+++ b/test/unit/test_registry.c
@@ -10,6 +10,7 @@ int register_host_tests_serial(struct kfs_test_case **out);
 int register_host_tests_kernel_main(struct kfs_test_case **out);
 int register_host_tests_printk(struct kfs_test_case **out);
 int register_host_tests_keyboard(struct kfs_test_case **out);
+int register_host_tests_string(struct kfs_test_case **out);
 
 // すべてのテストケースを一つにまとめる
 static struct kfs_test_case *all_cases = 0;
@@ -38,6 +39,8 @@ int register_host_tests(struct kfs_test_case **out)
 		int count_printk = register_host_tests_printk(&cases_printk);
 		struct kfs_test_case *cases_keyboard = 0;
 		int count_keyboard = register_host_tests_keyboard(&cases_keyboard);
+		struct kfs_test_case *cases_string = 0;
+		int count_string = register_host_tests_string(&cases_string);
 		// 動的確保は避け、静的最大数 (今は少数) を想定してスタック上に置けないので静的配列
 		static struct kfs_test_case merged[64];
 		int idx = 0;
@@ -59,6 +62,8 @@ int register_host_tests(struct kfs_test_case **out)
 			merged[idx++] = cases_printk[i];
 		for (int i = 0; i < count_keyboard && idx < 64; i++)
 			merged[idx++] = cases_keyboard[i];
+		for (int i = 0; i < count_string && idx < 64; i++)
+			merged[idx++] = cases_string[i];
 		all_cases = merged;
 		all_count = idx;
 	}


### PR DESCRIPTION
#64


## Summary
This pull request significantly expands the implementation and testing of string and memory helper functions in the codebase. It introduces full versions of standard functions like `strncpy`, `strlcpy`, `strcat`, `strncat`, `strcmp`, `strncmp`, `strchr`, `strrchr`, `strstr`, and memory operations (`memset`, `memcpy`, `memmove`, `memcmp`, `memchr`). Additionally, it updates the header file to declare these functions conditionally and adds comprehensive unit tests for all new functionality.

### String and Memory Function Implementations

* Added complete implementations for string manipulation functions (`strncpy`, `strlcpy`, `strcat`, `strncat`, `strcmp`, `strncmp`, `strchr`, `strrchr`, `strstr`, `strnlen`) and memory helpers (`memset`, `memcpy`, `memmove`, `memcmp`, `memchr`) to `lib/string.c`. [[1]](diffhunk://#diff-caf1d936b395dcac087bd2b6d8585de0e06695cfe00c899d9299dc9cfec2a118R11-R18) [[2]](diffhunk://#diff-caf1d936b395dcac087bd2b6d8585de0e06695cfe00c899d9299dc9cfec2a118R27-R210)
* Updated `include/linux/string.h` to declare all these functions, using conditional compilation to allow for architecture-specific overrides and introducing a typedef for `__kernel_size_t`.

### Unit Testing

* Added a new unit test file `test/unit/lib/test_string.c` with thorough test coverage for all string and memory functions, including edge cases and expected behaviors.
* Registered the new string tests in the test registry by updating `test/unit/test_registry.c` to include and merge the string test cases with the overall test suite. [[1]](diffhunk://#diff-d6ca11721c0f18bddae64aa472a2168d25847251870097ce50677a3e06a3e6e7R13) [[2]](diffhunk://#diff-d6ca11721c0f18bddae64aa472a2168d25847251870097ce50677a3e06a3e6e7R42-R43) [[3]](diffhunk://#diff-d6ca11721c0f18bddae64aa472a2168d25847251870097ce50677a3e06a3e6e7R65-R66)
