### PR TITLE
Fr/#65/set the printk back threshold to match linux procsyskernelprintk

### DIFF
--- a/include/kfs/kfs1_bonus.h
+++ b/include/kfs/kfs1_bonus.h
@@ -42,6 +42,13 @@ extern "C"
 		KFS_LOGLEVEL_DEFAULT = KFS_LOGLEVEL_WARNING,
 	};
 
+	extern int console_printk[4];
+
+#define console_loglevel (console_printk[0])
+#define default_message_loglevel (console_printk[1])
+#define minimum_console_loglevel (console_printk[2])
+#define default_console_loglevel (console_printk[3])
+
 	uint8_t kfs_vga_make_color(enum vga_color fg, enum vga_color bg);
 	uint16_t kfs_vga_make_entry(char c, uint8_t color);
 

--- a/kernel/printk.c
+++ b/kernel/printk.c
@@ -39,7 +39,7 @@ static void append_string(char **dst, size_t *remaining, size_t *written, const 
 }
 
 static void append_unsigned(char **dst, size_t *remaining, size_t *written, unsigned int value, unsigned int base,
-						int uppercase)
+							int uppercase)
 {
 	char buf[32];
 	int idx = 0;


### PR DESCRIPTION
#65

## Summary
This pull request refactors the kernel logging level management to use a consolidated `console_printk` array, improves log level clamping logic, and adds new tests for edge cases in formatted output and unknown prefix handling. The changes enhance configurability, robustness, and test coverage for the kernel's `printk` subsystem.

**Logging level management improvements:**

* Replaced individual loglevel variables with a single `console_printk` array, and introduced macros for accessing loglevel settings such as `console_loglevel`, `default_message_loglevel`, `minimum_console_loglevel`, and `default_console_loglevel` in `include/kfs/kfs1_bonus.h` and `kernel/printk.c`. [[1]](diffhunk://#diff-032ed2ae92cdd0be31dcf6eafaac7452d7f0d6c19ea7d05ae4d57168fbe1ac90R45-R51) [[2]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beL5-R11)
* Updated functions and logic to use new loglevel macros and array, including in loglevel clamping, message emission, and getter/setter functions. [[1]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beL132-R142) [[2]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beL151-R160) [[3]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beL165-R174) [[4]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beL183-R205) [[5]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beL221-R239)

**Robustness and correctness fixes:**

* Improved truncation and null-termination handling for output buffers in `append_char` and related formatted output functions. [[1]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beR23-R26) [[2]](diffhunk://#diff-84036d1e27f4207c783a3b876aef4e45340d30f43b1319bca382f5775a9b14beL43-R52)

**Test coverage enhancements:**

* Added a test to verify that `kfs_snprintf` correctly truncates and null-terminates output buffers. [[1]](diffhunk://#diff-7fbadac3f8f38bc73e1c64f808a4dbc330d5d7a38a5f43a6271e30286450eafeR132-R140) [[2]](diffhunk://#diff-7fbadac3f8f38bc73e1c64f808a4dbc330d5d7a38a5f43a6271e30286450eafeR226-R230)
* Added a test to ensure `printk` handles unknown prefix codes gracefully. [[1]](diffhunk://#diff-7fbadac3f8f38bc73e1c64f808a4dbc330d5d7a38a5f43a6271e30286450eafeR190-R212) [[2]](diffhunk://#diff-7fbadac3f8f38bc73e1c64f808a4dbc330d5d7a38a5f43a6271e30286450eafeR226-R230)
* Updated loglevel clamping test to use the new `minimum_console_loglevel` macro for consistency.

These changes collectively improve the flexibility, reliability, and maintainability of the kernel logging subsystem.
