### PR TITLE
ref: Updated with Japanese comments to clarify the multiboot header c…

### DIFF
--- a/arch/i386/boot/boot.S
+++ b/arch/i386/boot/boot.S
@@ -1,38 +1,37 @@
-/* Declare constants for the multiboot header. */
-.set ALIGN,    1<<0             /* align loaded modules on page boundaries */
-.set MEMINFO,  1<<1             /* provide memory map */
-.set FLAGS,    ALIGN | MEMINFO  /* this is the Multiboot 'flag' field */
-.set MAGIC,    0x1BADB002       /* 'magic number' lets bootloader find the header */
-.set CHECKSUM, -(MAGIC + FLAGS) /* checksum of above, to prove we are multiboot */
+/*このカーネルをどう扱ってロードしてほしいかを伝える設定 #defineみたいなもの */
+.set ALIGN,    1<<0             /* ページサイズ（通常4 KiB）に揃えて読み込んでほしい、と通知するフラグ */
+.set MEMINFO,  1<<1             /* ブートローダからカーネルに mem_lower/mem_upper 情報を multiboot_info に詰めて渡すよう要求するフラグ */
+.set FLAGS,    ALIGN | MEMINFO  /* 上記フラグをまとめたもの */
+.set MAGIC,    0x1BADB002       /* 「マルチブートヘッダが正しく存在すること」をブートローダへ知らせるための固定値 */
+.set CHECKSUM, -(MAGIC + FLAGS) /* 破損検出のための軽量チェック。 */
 
-/* Multiboot header must be within first 8 KiB and 4-byte aligned */
+/* マルチブートヘッダは最初の8KiB内に存在し、4バイト単位で整列されなければならない */
 .section .multiboot
-.align 4
-.long MAGIC
-.long FLAGS
-.long CHECKSUM
+.align 4 /* 同セクション内での変数(.multibootセクションの場合MAGIC, FLAGS, CHECKSUM)の値を4バイト整列する */
+.long MAGIC /* マルチブートヘッダのマジックナンバーを配置 */
+.long FLAGS /* フラグを配置 */
+.long CHECKSUM /* チェックサムを配置 */
 
-/* 16 KiB stack, 16-byte aligned */
+/* 16KiBのスタック領域を確保 */
 .section .bss
-.align 16
+.align 16 /* x86 の System V ABI ではスタックが 16バイト境界に揃っていることが前提になっているから */
 stack_bottom:
-.skip 16384
+.skip 16384 /* スタック領域が枯渇しないためのある程度の大きさの16KiB分の領域を確保 */
 stack_top:
 
-.section .text
-.global _start
-.type _start, @function
+.section .text /* コードセクションの開始 */
+.global _start /* リンカに_startシンボルをエクスポートするよう指示 */
+.type _start, @function /* _startシンボルが関数であることをリンカに伝える */
 _start:
-    /* Set up stack */
+    /* スタックを設定 */
     mov $stack_top, %esp
 
-    /* Enter high-level kernel */
+    /* 高レベルカーネルに入る */
     call start_kernel
 
-    /* If returns, halt forever */
+    /* ここで戻ってきた場合は無限停止 */
     cli
 1:  hlt
     jmp 1b
 
-.size _start, . - _start
-
+.size _start, . - _start /* _start関数のサイズを計算してリンカに伝える */


### PR DESCRIPTION
#98 


## Summary
This pull request updates the comments in the `arch/i386/boot/boot.S` file to provide more detailed and explanatory documentation, primarily in Japanese. The code logic remains unchanged, but the comments now offer clearer guidance on the purpose and behavior of each section, which should make the boot process and multiboot header structure easier to understand for future maintainers.

Documentation improvements:

* Expanded and translated comments throughout `boot.S` to explain multiboot header constants, alignment requirements, and stack setup, with detailed Japanese descriptions for each step.
* Clarified the purpose of alignment directives and the rationale for stack size and alignment based on x86 System V ABI requirements.
* Provided explicit explanations for each field in the multiboot header and the boot sequence, including the reasoning behind magic numbers, flags, and checksum usage.
* Added step-by-step comments for the boot process, including stack initialization, kernel entry, and the halt loop, making the boot sequence easier to follow.
