### PR TITLE
ref: Improve comments for port I/O functions in io.h

### DIFF
--- a/include/asm-i386/io.h
+++ b/include/asm-i386/io.h
@@ -7,12 +7,13 @@
 extern "C"
 {
 #endif
-
-	/* Basic port I/O helpers (non-inlined wrappers kept weak in C sources for test overriding). */
+	/** ポートマップドI/O **/
+	/* I/Oポート番号port指定のデバイスに対してvalを出力する */
 	static inline void outb(uint16_t port, uint8_t val)
 	{
 		__asm__ volatile("outb %0, %1" : : "a"(val), "Nd"(port));
 	}
+	/* I/Oポート番号port指定のデバイスに対してvalを入力する */
 	static inline uint8_t inb(uint16_t port)
 	{
 		uint8_t r;


### PR DESCRIPTION
#107 
**Stdin/stdout is NOT PMIO, but MMIO!!!!!**