### PR TITLE
FR/#248/skip-recipes-where-the-target-file-is-newer-than-the-dependent-filei-in-makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,17 +97,33 @@ iso-uefi: kernel grub-uefi.cfg
 
 else
 
-# --- Wrapper: run the same targets inside Docker ---
-kernel: ensure-image
+define ensure_image
+	@if ! $(DOCKER) image inspect $(IMAGE) >/dev/null 2>&1; then \
+		echo "Building Docker image from arch/$(ISA)/compile.dockerfile..."; \
+		$(DOCKER) build --platform $(DOCKER_PLATFORM) -f arch/$(ISA)/compile.dockerfile -t $(IMAGE) .; \
+	fi
+	@echo "Using Docker image: $(IMAGE)"
+endef
+
+$(KERNEL): $(KERNEL_SRCS_C) $(KERNEL_SRCS_S) $(KERNEL_SRCS_H) arch/$(ISA)/boot/linker.ld
+	$(call ensure_image)
 	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 make -j$(shell nproc) kernel'
+
+kernel: $(KERNEL)
 
 iso: iso-bios
 
-iso-bios: ensure-image
+$(ISO_BIOS): $(KERNEL) grub-bios.cfg
+	$(call ensure_image)
 	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 make -j$(shell nproc) iso-bios'
 
-iso-uefi: ensure-image
+iso-bios: $(ISO_BIOS)
+
+$(ISO_UEFI): $(KERNEL) grub-uefi.cfg
+	$(call ensure_image)
 	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 make -j$(shell nproc) iso-uefi'
+
+iso-uefi: $(ISO_UEFI)
 
 endif
 
@@ -162,4 +178,4 @@ fmt:
 		&& clang-format -i -style="{BasedOnStyle: Microsoft, IndentWidth: 4, TabWidth: 4, UseTab: Always, InsertBraces: true}" $(KERNEL_SRCS_C) $(TEST_SRCS_C) $(KERNEL_SRCS_H) $(TEST_SRCS_H) \
 		&& shfmt -w $(TEST_SRCS_SH)'
 
-.PHONY: all kernel iso-bios iso-uefi run run-iso-bios run-kernel run-iso-uefi clean fclean re ensure-image test coverage fmt
+.PHONY: all iso run run-iso-bios run-kernel run-iso-uefi clean fclean re ensure-image test unit integration coverage fmt

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -89,14 +89,6 @@ $(BUILD_DIR)/coverage/%.o: ./coverage/%.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
-# Log directory
-$(LOGDIR):
-	@mkdir -p $(LOGDIR)
-
-# Report directory
-$(REPORT_DIR):
-	@mkdir -p $(REPORT_DIR)
-
 -include $(DEPS)
 
 kernel: $(KERNEL)
@@ -160,6 +152,13 @@ fclean: clean
 	@rm -f $(KERNEL) $(ISO_BIOS) $(ISO_UEFI)
 
 re: fclean all
+
+# Log / report directories (needed by run-iso-bios on both host and container)
+$(LOGDIR):
+	@mkdir -p $(LOGDIR)
+
+$(REPORT_DIR):
+	@mkdir -p $(REPORT_DIR)
 
 # ===== Run with QEMU (prefer host, fallback to container) =====
 run: run-iso-bios

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -120,18 +120,36 @@ unit-bios: iso-bios
 
 else
 
-# --- Wrapper: run the same targets inside Docker ---
-kernel: ensure-image
+define ensure_image
+	@if ! $(DOCKER) image inspect $(IMAGE) >/dev/null 2>&1; then \
+		echo "Building Docker image from arch/$(ISA)/compile.dockerfile..."; \
+		$(DOCKER) build --platform $(DOCKER_PLATFORM) -f ../../arch/$(ISA)/compile.dockerfile -t $(IMAGE) .; \
+	fi
+	@echo "Using Docker image: $(IMAGE)"
+endef
+
+$(KERNEL): $(SRCS_C) $(SRCS_S) $(BOOTSTRAP) $(COVERAGE_C) ../../arch/$(ISA)/boot/linker.ld
+	$(call ensure_image)
 	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 COVERAGE_BUILD=$(COVERAGE_BUILD) make -j$(shell nproc) kernel'
 
-iso-bios: ensure-image
+kernel: $(KERNEL)
+
+$(ISO_BIOS): $(KERNEL) ./grub-bios.cfg
+	$(call ensure_image)
 	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 COVERAGE_BUILD=$(COVERAGE_BUILD) make -j$(shell nproc) iso-bios'
 
-iso-uefi: ensure-image
+iso-bios: $(ISO_BIOS)
+
+$(ISO_UEFI): $(KERNEL) ./grub-uefi.cfg
+	$(call ensure_image)
 	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 COVERAGE_BUILD=$(COVERAGE_BUILD) make -j$(shell nproc) iso-uefi'
 
-unit: ensure-image
-	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 COVERAGE_BUILD=$(COVERAGE_BUILD) make -j$(shell nproc) unit'
+iso-uefi: $(ISO_UEFI)
+
+# unit はテスト実行（QEMU）を伴うため常に run を呼ぶが，
+# $(ISO_BIOS) がファイルターゲットのためソース変更がなければ Docker ビルドはスキップされる
+unit: $(ISO_BIOS)
+	$(MAKE) run
 
 endif
 
@@ -178,4 +196,4 @@ coverage-instrument:
 	@echo "Instrumenting production code..."
 	@python3 coverage/insert_coverage_func.py ../../ build/coverage/ coverage/log/coverage_manifest.txt
 
-.PHONY: all kernel iso-bios iso-uefi run run-iso-bios clean fclean re ensure-image unit test coverage coverage-instrument
+.PHONY: all run run-iso-bios clean fclean re ensure-image unit test coverage coverage-instrument

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -141,7 +141,8 @@ iso-uefi: $(ISO_UEFI)
 # unit はテスト実行（QEMU）を伴うため常に run を呼ぶが，
 # $(ISO_BIOS) がファイルターゲットのためソース変更がなければ Docker ビルドはスキップされる
 unit: $(ISO_BIOS)
-	$(MAKE) run
+	$(call ensure_image)
+	@$(DOCKER_RUN) /bin/bash -lc 'IN_DOCKER=1 COVERAGE_BUILD=$(COVERAGE_BUILD) make run'
 
 endif
 


### PR DESCRIPTION
#248 