### PR TITLE
fix: Restore shell foreground before printing job status

### DIFF
--- a/kernel/shell/shell.c
+++ b/kernel/shell/shell.c
@@ -108,7 +108,14 @@ static void execute_external_command(const char *cmd, shell_cmd_fn fn, const cha
 					int job_id = shell_jobs_add(pid, pid, cmd, 1);
 					if (job_id > 0)
 					{
+						/** 文字を出力する前に，shell に foreground を戻す
+						 * @brief バックグラウンド状態にあるシェルプロセスが文字列を出力しようとすると
+						 *        SIGTTOUが送信され，シェルが停止してしまうため．
+						 * @ref sys_write();
+						 */
+						tcsetpgrp(0, getpgrp());
 						printf("[%d] Stopped %s\n", job_id, cmd);
+						return;
 					}
 				}
 			}


### PR DESCRIPTION
[Bug]: Sleep Stops. Shell Sleeps Forever #320

## Root cause
After the foreground job (`sleep`) is stopped by `Ctrl-Z`, the shell regains control via `waitpid(WUNTRACED)` and proceeds to print a status message.
However, at this point the shell is still in the background process group of the controlling terminal.
As a result, when the shell attempts to write to the terminal, the kernel sends `SIGTTOU`, suspending the shell itself.
Thus, the shell falls asleep right after successfully stopping `sleep`.

## Fix
Restore the shell to the foreground process group **before** performing any terminal output.
This ensures that printing job-control messages does not trigger `SIGTTOU`.

```c
tcsetpgrp(0, getpgrp());
printf("[%d] Stopped %s\n", job_id, cmd);
````